### PR TITLE
Short titles (issue #4)

### DIFF
--- a/R/paged.R
+++ b/R/paged.R
@@ -35,6 +35,6 @@ html_paged = function(
 pagedjs_dependency = function(css = NULL) {
   list(htmltools::htmlDependency(
     'paged', packageVersion('pagedown'), src = pkg_resource(),
-    script = 'js/paged.js', stylesheet = file.path('css', css), all_files = FALSE
+    script = c('js/config.js', 'js/paged.js'), stylesheet = file.path('css', css), all_files = FALSE
   ))
 }

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -28,7 +28,7 @@ HTML and CSS still cannot beat other dominating tools like Word or LaTeX when it
 
 # Applications 
 
-# Tests
+# Tests {data-short-title="Alt. level1 running title"}
 
 Test cross-references of pages: [Paged.js](#pagedjs).
 

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -7,7 +7,7 @@
 }
 
 /* store some string variables */
-.shorttitle {
+.shorttitle1 {
   string-set: h1-text content(text);
 }
 h2 {
@@ -117,7 +117,7 @@ a[href^="http"]:not([class="uri"])::after {
 }
 
 /* misc elements */
-.shorttitle {
+.shorttitle1 {
   display: none;
 }
 .subtitle span {

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -7,7 +7,7 @@
 }
 
 /* store some string variables */
-h1 {
+.shorttitle {
   string-set: h1-text content(text);
 }
 h2 {

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -52,6 +52,9 @@
   overflow: hidden;
 }
 .running-h2-title:before {
+  /* We would want to write: */
+  /* content: string(h2-text, start); */
+  /* However, this is yet unsupported by Paged.js, see https://gitlab.pagedmedia.org/tools/pagedjs/issues/38 */
   content: string(h2-text);
 }
 @page :right {

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -10,7 +10,8 @@
 .shorttitle1 {
   string-set: h1-text content(text);
 }
-h2 {
+
+.shorttitle2 {
   string-set: h2-text content(text);
 }
 
@@ -117,7 +118,7 @@ a[href^="http"]:not([class="uri"])::after {
 }
 
 /* misc elements */
-.shorttitle1 {
+.shorttitle1, .shorttitle2 {
   display: none;
 }
 .subtitle span {

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -4,6 +4,7 @@
   --height: 9in;
   --color-paper: white;
   --color-mbox: rgba(0, 0, 0, 0.2);
+  --running-title-width: 2.5in;
 }
 
 /* store some string variables */
@@ -22,24 +23,48 @@
 @page :blank {
 
 }
+
+/* left page */
+.running-h1-title {
+  position: running(runningH1Title);
+  width: var(--running-title-width);
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.running-h1-title:before {
+  content: string(h1-text);
+}
 @page :left {
   @top-left {
     content: counter(page);
   }
   @top-right {
-    content: string(h1-text);
+    content: element(runningH1Title);
     white-space: nowrap !important;
   }
+}
+
+/* right page */
+.running-h2-title {
+  position: running(runningH2Title);
+  width: var(--running-title-width);
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.running-h2-title:before {
+  content: string(h2-text);
 }
 @page :right {
   @top-right {
     content: counter(page);
   }
   @top-left {
-    content: string(h2-text);
+    content: element(runningH2Title);
     white-space: nowrap !important;
   }
 }
+
+/* New chapter page */
 @page chapter:first {
   @top-left {
     content: none;

--- a/inst/resources/html/default.html
+++ b/inst/resources/html/default.html
@@ -98,6 +98,10 @@ $endif$
 
 <body>
 
+<div class="running-h1-title"></div>
+
+<div class="running-h2-title"></div>
+
 $if(theme)$
 <div class="container-fluid main-container">
 $endif$

--- a/inst/resources/html/default.html
+++ b/inst/resources/html/default.html
@@ -110,7 +110,7 @@ $endfor$
 $if(title)$
 <div id="$idprefix$header" class="title-page">
 $if(shorttitle)$
-<h1 class="shorttitle">$shorttitle$</h1>
+<h1 class="shorttitle1">$shorttitle$</h1>
 $endif$
 <h1 class="title">$title$</h1>
 $if(subtitle)$

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -14,7 +14,13 @@ function appendShortTitleSpans(level) {
       var span = document.createElement('span');
       span.className = 'shorttitle' + level;
       span.innerText = runningTitle;
-      div.insertBefore(span, mainHeader);
+      mainHeader.insertAdjacentElement('afterend', span);
+      if (level == 1 && div.querySelector('.level2') === null) {
+        var span2 = document.createElement('span');
+        span2.className = 'shorttitle2';
+        span2.innerText = ' ';
+        span.insertAdjacentElement('afterend', span2);
+      }
     }
 
     for (const div of divs) {

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -1,5 +1,8 @@
 // Configuration script for paged.js
-
+/* A factory returning a function that appends short titles spans.
+   The text content of these spans are reused for running titles (see default.css).
+   Argument: level - An integer between 1 and 6.
+*/
 const appendShortTitleSpans = (level) => {
   return () => {
     return new Promise((resolve, reject) => {

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -1,42 +1,45 @@
 // Configuration script for paged.js
-/* A factory returning a function that appends short titles spans.
-   The text content of these spans are reused for running titles (see default.css).
-   Argument: level - An integer between 1 and 6.
-*/
-function appendShortTitleSpans(level) {
-  return async () => {
-    var divs = Array.from(document.getElementsByClassName('level' + level));
 
-    async function addSpan(div) {
-      var mainHeader = div.getElementsByTagName('h' + level)[0];
-      var mainTitle = mainHeader.textContent;
-      var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
-      var span = document.createElement('span');
-      span.className = 'shorttitle' + level;
-      span.innerText = runningTitle;
-      mainHeader.insertAdjacentElement('afterend', span);
-      if (level == 1 && div.querySelector('.level2') === null) {
-        var span2 = document.createElement('span');
-        span2.className = 'shorttitle2';
-        span2.innerText = ' ';
-        span.insertAdjacentElement('afterend', span2);
+(function() {
+  /* A factory returning a function that appends short titles spans.
+     The text content of these spans are reused for running titles (see default.css).
+     Argument: level - An integer between 1 and 6.
+  */
+  function appendShortTitleSpans(level) {
+    return async () => {
+      var divs = Array.from(document.getElementsByClassName('level' + level));
+
+      async function addSpan(div) {
+        var mainHeader = div.getElementsByTagName('h' + level)[0];
+        var mainTitle = mainHeader.textContent;
+        var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
+        var span = document.createElement('span');
+        span.className = 'shorttitle' + level;
+        span.innerText = runningTitle;
+        mainHeader.insertAdjacentElement('afterend', span);
+        if (level == 1 && div.querySelector('.level2') === null) {
+          var span2 = document.createElement('span');
+          span2.className = 'shorttitle2';
+          span2.innerText = ' ';
+          span.insertAdjacentElement('afterend', span2);
+        }
       }
-    }
 
-    for (const div of divs) {
-      await addSpan(div);
+      for (const div of divs) {
+        await addSpan(div);
+      }
+    };
+  }
+
+  var appendShortTitles1 = appendShortTitleSpans(1);
+  var appendShortTitles2 = appendShortTitleSpans(2);
+
+  window.PagedConfig = {
+    before: () => {
+      return Promise.all([
+        appendShortTitles1(),
+        appendShortTitles2()
+      ]);
     }
   };
-}
-
-var appendShortTitles1 = appendShortTitleSpans(1);
-var appendShortTitles2 = appendShortTitleSpans(2);
-
-window.PagedConfig = {
-  before: () => {
-    return Promise.all([
-      appendShortTitles1(),
-      appendShortTitles2()
-    ]);
-  }
-};
+})();

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -7,17 +7,14 @@ function appendShortTitleSpans(level) {
   return async () => {
     var divs = Array.from(document.getElementsByClassName('level' + level));
 
-    function addSpan(div) {
-      return new Promise((resolve, reject) => {
-        var mainHeader = div.getElementsByTagName('h' + level)[0];
-        var mainTitle = mainHeader.textContent;
-        var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
-        var span = document.createElement('span');
-        span.className = 'shorttitle' + level;
-        span.innerText = runningTitle;
-        div.insertBefore(span, mainHeader);
-        resolve();
-      });
+    async function addSpan(div) {
+      var mainHeader = div.getElementsByTagName('h' + level)[0];
+      var mainTitle = mainHeader.textContent;
+      var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
+      var span = document.createElement('span');
+      span.className = 'shorttitle' + level;
+      span.innerText = runningTitle;
+      div.insertBefore(span, mainHeader);
     }
 
     for (const div of divs) {
@@ -35,6 +32,5 @@ window.PagedConfig = {
       appendShortTitles1(),
       appendShortTitles2()
     ]);
-  },
-  after: (flow) => { console.log("after", flow) },
+  }
 };

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -18,8 +18,14 @@ const appendShortTitleSpans = (level) => {
 };
 
 var appendShortTitles1 = appendShortTitleSpans(1);
+var appendShortTitles2 = appendShortTitleSpans(2);
 
 window.PagedConfig = {
-  before: appendShortTitles1,
+  before: () => {
+    return Promise.all([
+      appendShortTitles1(),
+      appendShortTitles2()
+    ]);
+  },
   after: (flow) => { console.log("after", flow) },
 };

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -3,10 +3,12 @@
    The text content of these spans are reused for running titles (see default.css).
    Argument: level - An integer between 1 and 6.
 */
-const appendShortTitleSpans = (level) => {
-  return () => {
-    return new Promise((resolve, reject) => {
-      Array.from(document.getElementsByClassName('level' + level)).forEach(div => {
+function appendShortTitleSpans(level) {
+  return async () => {
+    var divs = Array.from(document.getElementsByClassName('level' + level));
+
+    function addSpan(div) {
+      return new Promise((resolve, reject) => {
         var mainHeader = div.getElementsByTagName('h' + level)[0];
         var mainTitle = mainHeader.textContent;
         var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
@@ -14,11 +16,15 @@ const appendShortTitleSpans = (level) => {
         span.className = 'shorttitle' + level;
         span.innerText = runningTitle;
         div.insertBefore(span, mainHeader);
+        resolve();
       });
-      resolve();
-    });
+    }
+
+    for (const div of divs) {
+      await addSpan(div);
+    }
   };
-};
+}
 
 var appendShortTitles1 = appendShortTitleSpans(1);
 var appendShortTitles2 = appendShortTitleSpans(2);

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -1,21 +1,25 @@
 // Configuration script for paged.js
 
-const appendShortTitleSpans = () => {
-  return new Promise((resolve, reject) => {
-    Array.from(document.getElementsByClassName('level1')).forEach(div => {
-      var mainHeader = div.getElementsByTagName('h1')[0];
-      var mainTitle = mainHeader.textContent;
-      var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
-      var runningHeader = document.createElement('span');
-      runningHeader.className = 'shorttitle';
-      runningHeader.innerText = runningTitle;
-      div.insertBefore(runningHeader, mainHeader);
+const appendShortTitleSpans = (level) => {
+  return () => {
+    return new Promise((resolve, reject) => {
+      Array.from(document.getElementsByClassName('level' + level)).forEach(div => {
+        var mainHeader = div.getElementsByTagName('h' + level)[0];
+        var mainTitle = mainHeader.textContent;
+        var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
+        var span = document.createElement('span');
+        span.className = 'shorttitle' + level;
+        span.innerText = runningTitle;
+        div.insertBefore(span, mainHeader);
+      });
+      resolve();
     });
-    resolve();
-  });
+  };
 };
 
+var appendShortTitles1 = appendShortTitleSpans(1);
+
 window.PagedConfig = {
-  before: appendShortTitleSpans,
+  before: appendShortTitles1,
   after: (flow) => { console.log("after", flow) },
 };

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -1,0 +1,23 @@
+// Configuration script for paged.js
+
+function appendShortTitleSpans() {
+  Array.from(document.getElementsByClassName('level1')).forEach(div => {
+    var mainHeader = div.getElementsByTagName('h1')[0];
+    var mainTitle = mainHeader.textContent;
+    var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
+    var runningHeader = document.createElement('span');
+    runningHeader.className = 'shorttitle';
+    runningHeader.innerText = runningTitle;
+    div.insertBefore(runningHeader, mainHeader);
+  });
+}
+
+window.PagedConfig = {
+  before: () => {
+    return new Promise((resolve, reject) => {
+      appendShortTitleSpans();
+      resolve();
+    })
+  },
+  after: (flow) => { console.log("after", flow) },
+};

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -1,23 +1,21 @@
 // Configuration script for paged.js
 
-function appendShortTitleSpans() {
-  Array.from(document.getElementsByClassName('level1')).forEach(div => {
-    var mainHeader = div.getElementsByTagName('h1')[0];
-    var mainTitle = mainHeader.textContent;
-    var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
-    var runningHeader = document.createElement('span');
-    runningHeader.className = 'shorttitle';
-    runningHeader.innerText = runningTitle;
-    div.insertBefore(runningHeader, mainHeader);
+const appendShortTitleSpans = () => {
+  return new Promise((resolve, reject) => {
+    Array.from(document.getElementsByClassName('level1')).forEach(div => {
+      var mainHeader = div.getElementsByTagName('h1')[0];
+      var mainTitle = mainHeader.textContent;
+      var runningTitle = 'shortTitle' in div.dataset ? div.dataset.shortTitle : mainTitle;
+      var runningHeader = document.createElement('span');
+      runningHeader.className = 'shorttitle';
+      runningHeader.innerText = runningTitle;
+      div.insertBefore(runningHeader, mainHeader);
+    });
+    resolve();
   });
-}
+};
 
 window.PagedConfig = {
-  before: () => {
-    return new Promise((resolve, reject) => {
-      appendShortTitleSpans();
-      resolve();
-    })
-  },
+  before: appendShortTitleSpans,
   after: (flow) => { console.log("after", flow) },
 };


### PR DESCRIPTION
Following the discussion in #4, this PR implements:
- ellipsis when running titles are too long. Their width is controlled by a new CSS variable named `--running-title-width`.  
- the ability to provide alternative titles for running headers (levels 1 & 2). These alternative titles are declared with the `data-short-title` attribute. For instance,
```markdown
# Hello world {data-short-title="hello"}
```

As soon as the `attr()` method for `string-set()` is supported by paged.js (see [here](https://gitlab.pagedmedia.org/tools/pagedjs/wikis/Support-of-specifications#user-content-css-generated-content-for-paged-media-module)), we will be able to use a more straightforward way.
