### PR TITLE
Support MathJax (disabling paged.js auto mode)

### DIFF
--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -63,4 +63,21 @@ Cite @R-base and @R-pagedown.
 knitr::write_bib(c(.packages(), 'pagedown'), 'index.bib')
 ```
 
+## Test mathjax
+
+The following test comes from <http://www.cs.toronto.edu/~yujiali/test/mathjax.html>.
+
+How about some RBM stuff first:  
+$$
+  E(\mathbf{v}, \mathbf{h}) = -\sum_{i,j}w_{ij}v_i h_j - \sum_i b_i v_i - \sum_j c_j h_j
+$$
+It works! Multiline equations?
+$$
+  \begin{align}
+    p(v_i=1|\mathbf{h}) & = \sigma\left(\sum_j w_{ij}h_j + b_i\right) \\
+    p(h_j=1|\mathbf{v}) & = \sigma\left(\sum_i w_{ij}v_i + c_j\right)
+  \end{align}
+$$
+It also works. Inline equations? Here is an example: $p(x|y) = \frac{p(y|x)p(x)}{p(y)}$. It still works perfectly well.
+
 # Bibliography {-}

--- a/inst/resources/html/default.html
+++ b/inst/resources/html/default.html
@@ -201,6 +201,10 @@ $if(math)$
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>
+$else$
+<script>
+  window.PagedPolyfill.preview();
+</script>
 $endif$
 
 </body>

--- a/inst/resources/html/default.html
+++ b/inst/resources/html/default.html
@@ -25,6 +25,22 @@ $endif$
 
 <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
 
+<script type="text/javascript">
+  window.PagedConfig = {
+    auto: false
+  };
+
+  window.MathJax = {
+    AuthorInit: () => {
+      MathJax.Hub.Register.StartupHook("Begin", () => {
+        MathJax.Hub.Queue( () => {
+          window.PagedPolyfill.preview();
+        });
+      });
+    }
+  };
+</script>
+
 $for(header-includes)$
 $header-includes$
 $endfor$

--- a/inst/resources/html/default.html
+++ b/inst/resources/html/default.html
@@ -178,7 +178,7 @@ $if(math)$
     var script = document.createElement("script");
     script.type = "text/javascript";
     var src = "$if(mathjax)$$mathjax$$endif$";
-    if (src === "" || src === "true") src = "https://cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML";
+    if (src === "" || src === "true") src = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML";
     if (location.protocol !== "file:" && /^https?:/.test(src))
       src = src.replace(/^https?:/, '');
     script.src = src;


### PR DESCRIPTION
As explained in <https://www.pagedmedia.org/paginating-math/> referenced in #2 , we can disable the `auto` run of the Paged.js previewer and add this previewer to the MathJax's callback queue.

On the other hand, as MathJax is dynamically loaded, the only solution I've found is to use the [`window.MathJax` configuration object](http://docs.mathjax.org/en/latest/configuration.html#using-plain-javascript) to register the previewer in the callback queue.

This PR includes this script in the `default.html` file, but we could put it in a specific JS configuration file.

**edit:**  
We also could dynamically load MathJax and keep the auto mode for Paged.js.
I wrote a second PR #9 .  
I think I'd prefer to keep the auto mode for Paged.js. 