### PR TITLE
Move short titles spans styling rules to presentational hints

### DIFF
--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -146,9 +146,6 @@ a[href^="http"]:not([class="uri"])::after {
 }
 
 /* misc elements */
-.shorttitle1, .shorttitle2 {
-  display: none;
-}
 .subtitle span {
   font-size: .9em;
 }

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -36,11 +36,13 @@
         var span = document.createElement('span');
         span.className = 'shorttitle' + level;
         span.innerText = runningTitle;
+        span.style.display = "none";
         mainHeader.insertAdjacentElement('afterend', span);
         if (level == 1 && div.querySelector('.level2') === null) {
           var span2 = document.createElement('span');
           span2.className = 'shorttitle2';
           span2.innerText = ' ';
+          span2.style.display = "none";
           span.insertAdjacentElement('afterend', span2);
         }
       }


### PR DESCRIPTION
Fix #13 
I've visually tested on the current `index.Rmd` document, it is OK.