### PR TITLE
Add support for list of tables, list of figures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports: rmarkdown, bookdown, htmltools, xfun
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown
 BugReports: https://github.com/rstudio/pagedown/issues
+SystemRequirements: Pandoc (>= 2.2.1)
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.0

--- a/R/paged.R
+++ b/R/paged.R
@@ -21,7 +21,9 @@ html_paged = function(
   ..., css = c('default-fonts', 'default'), theme = NULL,
   template = pkg_resource('html', 'paged.html')
 ) {
-  html_format(..., css = css, theme = theme, template = template, .pagedjs = TRUE)
+  html_format(..., css = css, theme = theme, template = template, .pagedjs = TRUE,
+              .pandoc_args = c("--lua-filter", pkg_resource('lua', 'loft.lua'))
+  )
 }
 
 pagedown_dependency = function(css = NULL, js = FALSE) {
@@ -32,7 +34,10 @@ pagedown_dependency = function(css = NULL, js = FALSE) {
   ))
 }
 
-html_format = function(..., css, template, .dependencies = NULL, .pagedjs = FALSE) {
+html_format = function(
+  ..., css, template, pandoc_args = NULL, .dependencies = NULL,
+  .pagedjs = FALSE, .pandoc_args = NULL
+) {
   css2 = grep('[.]css$', css, value = TRUE, invert = TRUE)
   css  = setdiff(css, css2)
   check_css(css2)
@@ -42,5 +47,7 @@ html_format = function(..., css, template, .dependencies = NULL, .pagedjs = FALS
       pagedown_dependency(xfun::with_ext(css2, '.css'), .pagedjs)
     ))
   }
-  html_document2(..., css = css, template = template)
+  html_document2(..., css = css, template = template,
+                 pandoc_args = c(.pandoc_args, pandoc_args)
+  )
 }

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -30,13 +30,31 @@ HTML and CSS still cannot beat other dominating tools like Word or LaTeX when it
 
 # Supported features
 
+## Lists of Tables and Figures
+
+Lists of tables and/or figures can be inserted in the document using the `lot` and `lof` variables.  
+You also can customize their titles with the `lot-title` and `lof-title` variables in the YAML header, for instance:
+
+```yaml
+---
+title: "A document with lists of tables and figures"
+output: pagedown::html_paged
+toc-title: Contents
+bibliography: index.bib
+lot: true
+lot-title: "Tables"
+lof: true
+lof-title: "Figures"
+---
+```
+
 ## Links
 
 In markdown, the usual ways to insert links are _automatic_ and _inline_ links.
 
 ### Automatic links
 
-_Automatic links_ are created using pointy brackets, e.g `<https://bookdown.org/>`.  
+_Automatic links_ are created using pointy brackets, e.g. `<https://bookdown.org/>`.  
 The full URL is then inserted in the final document <https://bookdown.org/>.  
 This is convenient for a short and meaningful URL.
 

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -118,8 +118,8 @@ a[href^="http"]:not([class="uri"])::after {
   content: " (page " target-counter(attr(href), page) ")";
 }
 
-/* TOC */
-.toc ul {
+/* TOC, LOT, LOF */
+.toc ul, .lot ul, .lof ul {
   list-style: none;
   padding-left: 0;
   overflow-x: hidden;
@@ -127,18 +127,18 @@ a[href^="http"]:not([class="uri"])::after {
 .toc li li {
   padding-left: 1em;
 }
-.toc a {
+.toc a, .lot a, .lof a {
   text-decoration: none;
   background: white;
   padding-right: .33em;
 }
-.toc a::after {
+.toc a::after, .lot a::after, .lof a::after {
   /* content: leader(dotted) target-counter(attr(href), page); */
   content: target-counter(attr(href), page);
   float: right;
   background: white;
 }
-.toc .leaders::before {
+.toc .leaders::before, .lot .leaders::before, .lof .leaders::before {
   float: left;
   width: 0;
   white-space: nowrap;

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -114,7 +114,7 @@ a[href^="http"]:not([class="uri"])::after {
   hyphens: none;
   word-break: break-all;
 }
-.main a[href^="#"]:not([class^="footnote-"]):not([href*=":"])::after {
+.main a[href^="#"]:not([class^="footnote-"]):not([href^="#fig-"]):not([href^="#tab-"])::after {
   content: " (page " target-counter(attr(href), page) ")";
 }
 

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -13,6 +13,21 @@
 
   var runMathJax = getBeforeAsync();
 
+  // bookdown uses ids of the form #fig:something #tab:something
+  // Paged.js crashes when it looks for the page number of an id containing a
+  // colon, see https://stackoverflow.com/questions/45110893/select-elements-by-attributes-with-colon
+  // We need to sanitize the ids and the href
+  async function sanitizeIds() {
+    var ids = document.querySelectorAll('*[id*="\\:"]');
+    var links = document.querySelectorAll('*[href*="\\:"]');
+    for (var item of ids) {
+      item.id = item.id.replace(/:/, "-");
+    }
+    for (var link of links) {
+      link.href = link.getAttribute("href").replace(/:/, "-");
+    }
+  }
+
   // This function expands the links in the lists of figures or tables (loft)
   async function expandLinksInLoft() {
     var items = document.querySelectorAll('.lof li, .lot li');
@@ -69,6 +84,7 @@
 
   window.PagedConfig = {
     before: async () => {
+      await sanitizeIds();
       await expandLinksInLoft();
       await Promise.all([
         addLeadersSpans(),

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -26,7 +26,7 @@
 
   // This function add spans for leading symbols.
   async function addLeadersSpans() {
-    var anchors = document.querySelectorAll('.toc a');
+    var anchors = document.querySelectorAll('.toc a, .lof a, .lot a');
     for (var a of anchors) {
       a.innerHTML = a.innerHTML + '<span class="leaders"></span>';
     }

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -19,12 +19,14 @@
   // We need to sanitize the ids and the href
   async function sanitizeIds() {
     var ids = document.querySelectorAll('*[id*="\\:"]');
-    var links = document.querySelectorAll('*[href*="\\:"]');
-    for (var item of ids) {
-      item.id = item.id.replace(/:/, "-");
-    }
-    for (var link of links) {
-      link.href = link.getAttribute("href").replace(/:/, "-");
+    for (var elem of ids) {
+      var id = elem.id;
+      var selector = id.replace(/:/, "\\:");
+      var links = document.querySelectorAll('*[href*="#' + selector + '"]');
+      elem.id = elem.id.replace(/:/, "-");
+      for (var link of links) {
+        link.href = link.getAttribute("href").replace(/:/, "-");
+      }
     }
   }
 

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -13,6 +13,17 @@
 
   var runMathJax = getBeforeAsync();
 
+  // This function expands the links in the lists of figures or tables (loft)
+  async function expandLinksInLoft() {
+    var items = document.querySelectorAll('.lof li, .lot li');
+    for (var item of items) {
+      var anchor = item.firstChild;
+      anchor.innerText = item.innerText;
+      item.innerText = '';
+      item.append(anchor);
+    }
+  }
+
   // This function add spans for leading symbols.
   async function addLeadersSpans() {
     var anchors = document.querySelectorAll('.toc a');
@@ -58,6 +69,7 @@
 
   window.PagedConfig = {
     before: async () => {
+      await expandLinksInLoft();
       await Promise.all([
         addLeadersSpans(),
         appendShortTitles1(),

--- a/inst/resources/lua/loft.lua
+++ b/inst/resources/lua/loft.lua
@@ -1,0 +1,121 @@
+--[[
+    A pandoc filter that generates Lists Of Figures and Tables (loft).
+    This filter enables the lot and lof options as in LaTeX output formats.
+
+    The user can also customise the titles with lot-title and lof-title:
+    ---
+    lof:
+    lof-title: "Illustrations" # markdown styling is supported
+    ---
+--]]
+
+local options = {}     -- where we store pandoc Meta
+local tablesList = {}  -- where we store the list of tables
+local figuresList = {} -- where we store the list of figures
+
+-- The following function stores pandoc Meta in the options local variable
+local function getMeta(meta)
+  options = meta
+  -- If there is no given titles, use default titles
+  if not options["lot-title"] then
+    options["lot-title"] = pandoc.MetaInlines("List of Tables")
+  end
+  if not options["lof-title"] then
+    options["lof-title"] = pandoc.MetaInlines("List of Figures")
+  end
+  return nil -- Do not modify Meta
+end
+
+-- This function is called only for Div of class figure inserted by bookdown
+local function getFigCaption(div)
+  local listOfBlocks = div.content
+  local found
+  for i, block in ipairs(listOfBlocks) do
+    if block.t == "RawBlock" then
+      if block.c[2] == '<p class="caption">' then
+        found = i + 1
+        break
+      end
+    end
+  end
+  if found then
+    return pandoc.utils.stringify(div.content[found])
+  else
+    return nil
+  end
+end
+
+-- This function looks for div of class figure.
+-- It builds and saves the items used by the list of figures.
+local function addFigRef(div)
+  local captionText
+  local figref
+
+  -- do not build the lof if not required
+  if not options.lof then return nil end
+
+  if div.classes:includes("figure") then
+    captionText = getFigCaption(div)
+    if not captionText then return nil end
+
+    -- build figure reference from figure caption
+    figref = "@ref" .. string.gsub(captionText, "#", "")
+    figref = string.gsub(figref, "%)", ") ") -- add a space
+    -- insert figure reference in figuresList
+    table.insert(figuresList, {pandoc.Plain(pandoc.Str(figref))})
+  end
+  return nil -- Do not modify Div
+end
+
+-- This function inspects the tables captions.
+-- When a bookdown id is found, it builds and saves the items used by
+--  the list of tables.
+local function addTabRef(tab)
+  local caption
+  local found
+  local tabref
+
+  -- do not build the lot if not required
+  if not options.lot then return nil end
+
+  caption = pandoc.utils.stringify(tab.caption)
+  -- test the presence of a bookdown table id
+  found = string.find(caption, "%(#tab:.*%)")
+  if found then
+    -- build table reference from table caption
+    tabref = "@ref" .. string.gsub(caption, "#", "")
+    tabref = string.gsub(tabref, "%)", ") ") -- add a space
+    -- insert table reference in tablesList
+    table.insert(tablesList, {pandoc.Plain(pandoc.Str(tabref))})
+  end
+  return nil -- Do not modify Table
+end
+
+local function appendLoft(doc)
+  local lotHeader
+  local lofHeader
+  local idprefix = options.idprefix or ""
+
+  if options.lof then
+    table.insert(doc.blocks, 1, pandoc.BulletList(figuresList))
+    lofHeader =
+      pandoc.Header(1,
+                    {table.unpack(options["lof-title"])},
+                    pandoc.Attr(idprefix .. "LOF", {"lof", "unnumbered"}, {})
+      )
+    table.insert(doc.blocks, 1, lofHeader)
+  end
+
+  if options.lot then
+    table.insert(doc.blocks, 1, pandoc.BulletList(tablesList))
+    lotHeader =
+      pandoc.Header(1,
+                    {table.unpack(options["lot-title"])},
+                    pandoc.Attr(idprefix .. "LOT", {"lot", "unnumbered"}, {})
+      )
+    table.insert(doc.blocks, 1, lotHeader)
+  end
+  return pandoc.Pandoc(doc.blocks, doc.meta)
+end
+
+return {{Meta = getMeta}, {Div = addFigRef, Table = addTabRef, Doc = appendLoft}}


### PR DESCRIPTION
Many books possess a list of tables (LOT) and/or a list of figures (LOF).
Pandoc already supports LOT and LOF for LaTeX output through the `lot` and `lof` variables.
The aim of this PR is to add similar support for pagedown.
It also introduces a `lot-title` and a `lof-title` variables that are of the same use of `toc-title`.

Technically, two points have to be mentioned:

- the support for LOT and LOF is achieved through a Pandoc filter. Since Pandoc 2 has a native support of lua filter, I wrote this filter in lua. This introduces a system dependency to Pandoc 2. I think it is not a big problem because the latest preview of RStudio already contains Pandoc 2.
-  I got a big issue with bookdown ids for figures and tables because they contain a colon (`:`). When Paged.js tries to find the page number for such an id, it internally calls `document.querySelector('id')` without escaping the colon. This leads to a crash. It seems to be [a well-known issue](https://stackoverflow.com/questions/45110893/select-elements-by-attributes-with-colon). I [opened an issue](https://gitlab.pagedmedia.org/tools/pagedjs/issues/70) in Paged.js and also sanitized the ids. 