### PR TITLE
New feature - Experimental support for footnotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports: rmarkdown, bookdown, htmltools, xfun
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown
 BugReports: https://github.com/rstudio/pagedown/issues
-SystemRequirements: Pandoc (>= 2.2.1)
+SystemRequirements: Pandoc (>= 2.2.3)
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.0

--- a/R/paged.R
+++ b/R/paged.R
@@ -30,7 +30,7 @@ html_paged = function(
 pagedown_dependency = function(css = NULL, js = FALSE) {
   list(htmltools::htmlDependency(
     'paged', packageVersion('pagedown'), src = pkg_resource(),
-    script = if (js) c('js/config.js', 'js/paged.js'),
+    script = if (js) c('js/config.js', 'js/paged.js', 'js/hooks.js'),
     stylesheet = file.path('css', css), all_files = FALSE
   ))
 }

--- a/R/paged.R
+++ b/R/paged.R
@@ -23,7 +23,7 @@ html_paged = function(
 ) {
   html_format(
     ..., css = css, theme = theme, template = template, .pagedjs = TRUE,
-    .pandoc_args = lua_filters('uri-to-fn.lua', 'loft.lua')
+    .pandoc_args = lua_filters('uri-to-fn.lua', 'loft.lua', 'footnotes.lua') # uri-to-fn.lua must come before footnotes.lua
   )
 }
 

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -77,6 +77,10 @@ links-to-footnotes: true
 ---
 ```
 
+## Footnotes
+
+The default behavior of pagedown is to render notes as endnotes because Paged.js does not natively support footnotes for now. However, we introduced an experimental support for footnotes. You can test it including `notes-as-footnotes: true` in the YAML header of your document. If you get any trouble with this experimental feature, please open an issue on GitHub.
+
 ## Tests {data-short-title="Some tests"}
 
 ### A list {data-short-title="An ordered list"}

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -79,7 +79,7 @@ links-to-footnotes: true
 
 ## Footnotes
 
-The default behavior of pagedown is to render notes as endnotes because Paged.js does not natively support footnotes for now. However, we introduced an experimental support for footnotes. You can test it including `notes-as-footnotes: true` in the YAML header of your document. If you get any trouble with this experimental feature, please open an issue on GitHub.
+The default behavior of pagedown is to render notes as endnotes because Paged.js does not natively support footnotes for now. However, we introduced an experimental support for footnotes. You can test it including `paged-footnotes: true` in the YAML header of your document. If you get any trouble with this experimental feature, please open an issue on GitHub.
 
 ## Tests {data-short-title="Some tests"}
 

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -161,6 +161,9 @@ img {
 .footnotes hr {
   border: none;
 }
+.footnote-break {
+  width: 1in;
+}
 body {
   hyphens: auto;
 }

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -1,0 +1,75 @@
+// Hooks for paged.js
+
+// Footnotes support
+Paged.registerHandlers(class extends Paged.Handler {
+  constructor(chunker, polisher, caller) {
+    super(chunker, polisher, caller);
+  }
+
+  beforeParsed(content) {
+    var footnotes = content.querySelectorAll('.footnote');
+
+    for (var footnote of footnotes) {
+      var parentElement = footnote.parentElement;
+      var footnoteCall = document.createElement('a');
+      var footnoteNumber = footnote.dataset.pagedownFootnoteNumber;
+
+      footnoteCall.className = 'footnote-ref'; // same class as Pandoc
+      footnoteCall.setAttribute('id', 'fnref' + footnoteNumber); // same notation as Pandoc
+      footnoteCall.setAttribute('href', '#' + footnote.id);
+      footnoteCall.innerHTML = '<sup>' + footnoteNumber +'</sup>';
+      parentElement.insertBefore(footnoteCall, footnote);
+
+      // Here comes a hack. Fortunately, it works with Chrome and FF.
+      var handler = document.createElement('p');
+      handler.className = 'footnoteHandler';
+      parentElement.insertBefore(handler, footnote);
+      handler.appendChild(footnote);
+      handler.style.display = 'inline-block';
+      handler.style.width = '100%';
+      handler.style.float = 'right';
+      handler.style.pageBreakInside = 'avoid';
+    }
+  }
+
+  afterRendered(pages) {
+    for (var page of pages) {
+      var footnotes = page.element.querySelectorAll('.footnote');
+      if (footnotes.length === 0) {
+        continue;
+      }
+
+      var pageContent = page.element.querySelector('.pagedjs_page_content');
+      var hr = document.createElement('hr');
+      var footnoteArea = document.createElement('div');
+
+      pageContent.style.display = 'flex';
+      pageContent.style.flexDirection = 'column';
+
+      hr.className = 'footnote-break';
+      hr.style.marginTop = 'auto';
+      hr.style.marginBottom = 0;
+      hr.style.marginLeft = 0;
+      hr.style.marginRight = 'auto';
+      pageContent.appendChild(hr);
+
+      footnoteArea.className = 'footnote-area';
+      pageContent.appendChild(footnoteArea);
+
+      for (var footnote of footnotes) {
+        var handler = footnote.parentElement;
+
+        footnoteArea.appendChild(footnote);
+        handler.parentNode.removeChild(handler);
+
+        footnote.innerHTML = '<sup>' + footnote.dataset.pagedownFootnoteNumber + '</sup>' + footnote.innerHTML;
+        footnote.style.fontSize = 'x-small';
+        footnote.style.marginTop = 0;
+        footnote.style.marginBottom = 0;
+        footnote.style.paddingTop = 0;
+        footnote.style.paddingBottom = 0;
+        footnote.style.display = 'block';
+      }
+    }
+  }
+});

--- a/inst/resources/lua/footnotes.lua
+++ b/inst/resources/lua/footnotes.lua
@@ -15,7 +15,7 @@ local function getMeta(meta)
 end
 
 local function noteToSpan(note)
-  if not options["notes-as-footnotes"] then return nil end
+  if not options["paged-footnotes"] then return nil end
   noteId = noteId + 1
   local inlines = pandoc.utils.blocks_to_inlines(note.content, {pandoc.Str'\010'}) -- insert \n between Pandoc's blocks
   local attr = {}

--- a/inst/resources/lua/footnotes.lua
+++ b/inst/resources/lua/footnotes.lua
@@ -1,0 +1,27 @@
+--[[
+    This filter transforms Pandoc's notes in spans.
+    See https://stackoverflow.com/questions/51548827/pandoc-lua-filter-how-to-preserve-footnotes-formatting
+    and https://github.com/jgm/pandoc/pull/4799
+
+    Requires Pandoc >= 2.2.3
+--]]
+
+local options = {} -- where we store pandoc Meta
+local noteId = 0 -- ids for notes
+
+local function getMeta(meta)
+  options = meta
+  return nil -- Do not modify Meta
+end
+
+local function noteToSpan(note)
+  if not options["notes-as-footnotes"] then return nil end
+  noteId = noteId + 1
+  local inlines = pandoc.utils.blocks_to_inlines(note.content, {pandoc.Str'\010'}) -- insert \n between Pandoc's blocks
+  local attr = {}
+  attr["data-pagedown-footnote-number"] = noteId
+  attr["style"] = "white-space: pre-line;" -- use pre-line to render \n
+  return pandoc.Span(inlines, pandoc.Attr("fn" .. noteId, {"footnote"}, attr))
+end
+
+return {{Meta = getMeta}, {Note = noteToSpan}}


### PR DESCRIPTION
The [CSS Generated Content for Paged Media Module WD](https://www.w3.org/TR/css-gcpm-3/) specifies a `footnote` value for the CSS `float` property. For now, Paged.js does not support this feature.

The aim of this PR is to introduce an experimental support for footnotes. It is experimental because it relies on a hack. Fortunately, it works well with Chrome and Firefox.

The PR has two parts.

1. A Pandoc filter that inserts the footnotes contents in `span`s as described in [example 7 of the GCPMD WD](https://www.w3.org/TR/css-gcpm-3/#creating-footnotes). This filter uses the `blocks_to_inlines` `lua` function that was [recently exposed](https://github.com/jgm/pandoc/pull/4799) in Pandoc 2.2.3.

1. A Paged.js hook. As far as I have tested, it works well. The idea behind this hook is to enclose each footnote `span` in a right-floating handler with 100% width before the chunker defines the pages layout. 
Here's an example:
![fnhandler](https://user-images.githubusercontent.com/19177171/47578882-d1796000-d94a-11e8-95ff-d2598ad8ee80.png)
With this handler, we keep a sufficient room for the footnotes on each page.  
After the chunker has finished its job, the hook builds a footnote area, inserts the footnotes in this area, and finally removes the handlers from the flow.  
I've tested different handlers, and the best results I have obtained is with `p` handlers.

I have to admit that this hook is very dirty but this is the only trick I've found and it seems intuitive to me.  
I hope you will like it!