### PR TITLE
Resume template-Fix issues with CSS only

### DIFF
--- a/inst/resources/css/resume.css
+++ b/inst/resources/css/resume.css
@@ -1,6 +1,6 @@
 @page{
   size: letter portrait;
-  margin: 1in;
+  margin: 1in 0.5in 1in 0.25in;
 }
 
 *{
@@ -9,11 +9,12 @@
 
 :root{
   --page-width: 8.5in;
-  --margin-right: 1in;
-  --margin-left: 1in;
+  --margin-right: 0.5in;
+  --margin-left: 0.25in;
   --content-width: calc(var(--page-width) - var(--margin-right) - var(--margin-left));
-  --main-width: 4.5in;
-  --sidebar-width: calc(var(--content-width) - var(--main-width));
+  --root-font-size: 13pt;
+  --sidebar-width: 15rem;
+  --main-width: calc(var(--content-width) - var(--sidebar-width));
   --decorator-horizontal-margin: 0.2in;
 
   --sidebar-horizontal-padding: 0.2in;
@@ -25,10 +26,14 @@
   --decorator-outer-dim: 9px;
   --decorator-border: 1px solid #ccc;
 
-  --row-blocks-padding-top: 5pt;
+  --row-blocks-padding-top: 0.5rem;
   --date-block-width: 0.6in;
 
-  --main-blocks-title-icon-offset-left: -19pt;
+  --main-blocks-title-icon-offset-left: calc(-17pt - 0.25 * var(--root-font-size));
+}
+
+html {
+  font-size: var(--root-font-size);
 }
 
 body{
@@ -57,7 +62,7 @@ a{
 #main{
   width: var(--main-width);
   padding: 0.25in 0.25in 0 0.25in;
-  font-size: 7pt;
+  font-size: 0.7rem;
 }
 
 #sidebar{
@@ -65,7 +70,7 @@ a{
   width: var(--sidebar-width);
   padding: 0.6in var(--sidebar-horizontal-padding);
   background-color: #f2f2f2;
-  font-size: 8.5pt;
+  font-size: 0.85rem;
   grid-column-start: 2;
 }
 
@@ -85,17 +90,17 @@ a{
 
 #title h1{
   font-weight: 300;
-  font-size: 18pt;
+  font-size: 1.8rem;
   line-height: 1.5;
 }
 
 #title h1 strong{
-  margin: auto 2pt auto 4pt;
+  margin: auto 0.2rem auto 0.4rem;
   font-weight: 600;
 }
 
 .subtitle{
-  font-size: 8pt;
+  font-size: 0.8rem;
 }
 
 #title .content {
@@ -116,7 +121,7 @@ a{
   /* XXX: 0.5px for aligning fx printing */
   left: calc((var(--date-block-width) + var(--decorator-horizontal-margin)));
   font-weight: 400;
-  font-size: 11pt;
+  font-size: 1.1rem;
   color: #555;
 }
 
@@ -171,9 +176,9 @@ a{
 
 .date{
   flex: 0 0 var(--date-block-width);
-  padding-top: calc(var(--row-blocks-padding-top) + 2.5pt) !important;
+  padding-top: calc(var(--row-blocks-padding-top) + 0.25rem) !important;
   padding-right: var(--decorator-horizontal-margin);
-  font-size: 7pt;
+  font-size: 0.7rem;
   text-align: right;
   line-height: 1;
 }
@@ -184,10 +189,10 @@ a{
 
 .date span:nth-child(2)::before{
   position: relative;
-  top: 1pt;
-  right: 5.5pt;
+  top: 0.1rem;
+  right: 0.55rem;
   display: block;
-  height: 10pt;
+  height: 1rem;
   content: '|';
 }
 
@@ -241,7 +246,7 @@ a{
 .details{
   flex: 1 0 0;
   padding-left: var(--decorator-horizontal-margin);
-  padding-top: calc(var(--row-blocks-padding-top) - 0.5pt) !important; /* not sure why but this is needed for better alignment */
+  padding-top: calc(var(--row-blocks-padding-top) - 0.05rem) !important; /* not sure why but this is needed for better alignment */
 }
 
 .details header{
@@ -249,7 +254,7 @@ a{
 }
 
 .details h3{
-  font-size: 9pt;
+  font-size: 0.9rem;
 }
 
 .main-block:not(.concise) .details div{
@@ -268,7 +273,7 @@ a{
 
 .details .place{
   float: left;
-  font-size: 7.5pt;
+  font-size: 0.75rem;
 }
 
 .details .location{
@@ -318,7 +323,7 @@ a{
 
 #sidebar h1{
   font-weight: 400;
-  font-size: 11pt;
+  font-size: 1.1rem;
 }
 
 .side-block{
@@ -334,7 +339,7 @@ a{
 }
 
 #contact li > i{
-  width: 9pt; /* for text alignment */
+  width: 0.9rem; /* for text alignment */
   text-align: right;
 }
 
@@ -351,7 +356,7 @@ a{
   position: absolute;
   bottom: var(--sidebar-horizontal-padding);
   right: var(--sidebar-horizontal-padding);
-  font-size: 7.5pt;
+  font-size: 0.75rem;
   font-style: italic;
   line-height: 1.1;
   text-align: right;

--- a/inst/resources/css/resume.css
+++ b/inst/resources/css/resume.css
@@ -58,7 +58,6 @@ a{
   width: var(--main-width);
   padding: 0.25in 0.25in 0 0.25in;
   font-size: 7pt;
-  grid-row: 1/-1;
 }
 
 #sidebar{
@@ -68,7 +67,6 @@ a{
   background-color: #f2f2f2;
   font-size: 8.5pt;
   grid-column-start: 2;
-  grid-row: 1/-1;
 }
 
 /* main */

--- a/inst/resources/css/resume.css
+++ b/inst/resources/css/resume.css
@@ -8,11 +8,13 @@
 }
 
 :root{
+  --pages-number: 2;
   --page-width: 8.5in;
   --margin-right: 1in;
   --margin-left: 1in;
-  --main-width: calc(6.4in - var(--margin-left));
-  --sidebar-width: calc(var(--page-width) - var(--main-width) - var(--margin-right));
+  --content-width: calc(var(--page-width) - var(--margin-right) - var(--margin-left));
+  --main-width: 4.5in;
+  --sidebar-width: calc(var(--content-width) - var(--main-width));
   --decorator-horizontal-margin: 0.2in;
 
   --sidebar-horizontal-padding: 0.2in;
@@ -31,13 +33,14 @@
 }
 
 body{
-  width: var(--page-width);
+  width: var(--content-width);
   font-family: "Open Sans", sans-serif;
   font-weight: 300;
   line-height: 1.3;
   color: #444;
   hyphens: auto;
   display: grid;
+  grid-template-rows: repeat(var(--pages-number), 100vh);
 }
 
 h1, h2, h3{
@@ -57,6 +60,7 @@ a{
   width: var(--main-width);
   padding: 0.25in 0.25in 0 0.25in;
   font-size: 7pt;
+  grid-row: 1/-1;
 }
 
 #sidebar{
@@ -66,6 +70,7 @@ a{
   background-color: #f2f2f2;
   font-size: 8.5pt;
   grid-column-start: 2;
+  grid-row: 1/-1;
 }
 
 /* main */
@@ -106,6 +111,7 @@ a{
 
 .main-block{
   margin-top: 0.1in;
+  page-break-inside: avoid;
 }
 
 #main h2{

--- a/inst/resources/css/resume.css
+++ b/inst/resources/css/resume.css
@@ -1,6 +1,6 @@
 @page{
   size: letter portrait;
-  margin: 0;
+  margin: 1in;
 }
 
 *{
@@ -9,9 +9,10 @@
 
 :root{
   --page-width: 8.5in;
-  --page-height: 11in;
-  --main-width: 6.4in;
-  --sidebar-width: calc(var(--page-width) - var(--main-width));
+  --margin-right: 1in;
+  --margin-left: 1in;
+  --main-width: calc(6.4in - var(--margin-left));
+  --sidebar-width: calc(var(--page-width) - var(--main-width) - var(--margin-right));
   --decorator-horizontal-margin: 0.2in;
 
   --sidebar-horizontal-padding: 0.2in;
@@ -31,13 +32,12 @@
 
 body{
   width: var(--page-width);
-  height: var(--page-height);
-  margin: 0;
   font-family: "Open Sans", sans-serif;
   font-weight: 300;
   line-height: 1.3;
   color: #444;
   hyphens: auto;
+  display: grid;
 }
 
 h1, h2, h3{
@@ -54,20 +54,18 @@ a{
 }
 
 #main{
-  float: left;
   width: var(--main-width);
   padding: 0.25in 0.25in 0 0.25in;
   font-size: 7pt;
 }
 
 #sidebar{
-  float: right;
   position: relative; /* for disclaimer */
   width: var(--sidebar-width);
-  height: 100%;
   padding: 0.6in var(--sidebar-horizontal-padding);
   background-color: #f2f2f2;
   font-size: 8.5pt;
+  grid-column-start: 2;
 }
 
 /* main */

--- a/inst/resources/css/resume.css
+++ b/inst/resources/css/resume.css
@@ -8,7 +8,6 @@
 }
 
 :root{
-  --pages-number: 2;
   --page-width: 8.5in;
   --margin-right: 1in;
   --margin-left: 1in;
@@ -40,7 +39,6 @@ body{
   color: #444;
   hyphens: auto;
   display: grid;
-  grid-template-rows: repeat(var(--pages-number), 100vh);
 }
 
 h1, h2, h3{


### PR DESCRIPTION
Here's a proposal to fix #15 with CSS rules only.

- margins are defined in `@page` rules. Chrome supports this rule but the user has to manually remove headers and footers before printing. With the `chrome_print()` function, it seems that we cannot remove headers/footers.
- the fonts sizes are increased by 30% (`rem` are used for font size instead of `pt`)
- the sidebar expands to all the pages