### PR TITLE
A mobile friendly rendering for html_paged documents

### DIFF
--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -5,6 +5,7 @@
   --color-paper: white;
   --color-mbox: rgba(0, 0, 0, 0.2);
   --running-title-width: 2.5in;
+  --screen-pages-spacing: 5mm;
 }
 
 /* generated content */
@@ -78,6 +79,7 @@ code {
 @media screen {
   body {
     background-color: var(--background);
+    margin: var(--screen-pages-spacing) auto 0 auto;
   }
   .pagedjs_pages {
     display: flex;
@@ -91,16 +93,23 @@ code {
     box-shadow: 0 0 0 1px var(--color-mbox);
     flex-shrink: 0;
     flex-grow: 0;
-    margin: auto auto 5mm auto;
+    margin: auto auto var(--screen-pages-spacing) auto;
   }
 }
 
 /* when a row can hold two pages, start first page on the right */
 @media (min-width: 12.32in) {
   .pagedjs_page {
-    margin: auto 0 5mm 0;
+    margin: auto 0 var(--screen-pages-spacing) 0;
   }
   .pagedjs_first_page {
     margin-left: var(--width);
+  }
+}
+
+/* use a fixed width body for mobiles */
+@media screen and (max-width:1180px)  {
+  body {
+    width: calc(var(--width) + 2 * var(--screen-pages-spacing));
   }
 }

--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width">
 <meta property="og:title" content="$pagetitle$" />
 $if(url)$<meta property="og:url" content="$url$" />$endif$
 $if(cover-image)$<meta property="og:image" content="$url$$cover-image$" />$endif$


### PR DESCRIPTION
The aim of this PR is to get a good rendering of `html_paged` documents on mobile devices.

Currently, when one opens a `html_paged` document with a mobile, the content is "zoomed in". 
At the first glance, we can see that the web page is not responsive. To see the whole page, the user has to pinch out first.

![iphone_master](https://user-images.githubusercontent.com/19177171/48142730-9f062600-e2ad-11e8-9a69-fc6eeb3ac7b2.png)

With this PR, the web page would be rendered as following (then, the user can zoom in):

![iphone_pr](https://user-images.githubusercontent.com/19177171/48143017-3c615a00-e2ae-11e8-9907-5e83d416e7aa.png)

As you can see, modifications are light in the source code.