### PR TITLE
Put the scrollTo call in PagedConfig.after

### DIFF
--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -79,6 +79,10 @@
         appendShortTitles2()
       ]);
       await runMathJax();
+    },
+    after: () => {
+      // scroll to the last position before the page is reloaded
+      window.scrollTo(0, sessionStorage.getItem('pagedown-scroll'));
     }
   };
 })();

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -105,8 +105,5 @@ Paged.registerHandlers(class extends Paged.Handler {
         paragraphSecondPage.parentElement.style.setProperty('list-style', 'inherit', 'important');
       }
     }
-
-    // scroll to the last position before the page is reloaded
-    window.scrollTo(0, sessionStorage.getItem('pagedown-scroll'));
   }
 });


### PR DESCRIPTION
This is a small modification of https://github.com/rstudio/pagedown/commit/9d743a9cf89615901dade0b5ff186efd7ca79565 for #36 

This comes from the design of the Paged.js API: hooks and handlers are used to tweak Paged.js.
Here, the goal is to scroll the window after the Paged.js previewer ran. 
That's why I think the right place for `scrollTo()` is in `PagedConfig.after`
