### PR TITLE
Fix issue 1: roman numerals in front matter and decimal in the main body

### DIFF
--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -262,6 +262,16 @@ lof-title: "Figures"
 ---
 ```
 
+## Front matter
+
+By default, the front matter is composed of the cover, the table of contents and the lists of figures and tables if any. The only difference between the front matter pages and the main content pages is the style of the page numbers.
+
+You can add extra sections to the front matter using the `front-matter` class. For instance, if you want to add a preface to the front matter, you need to write:
+
+```markdown
+# Preface {.front-matter .unnumbered}
+```
+
 ## Links
 
 In Markdown, the usual ways to insert links are _automatic_ and _inline_ links.

--- a/inst/resources/css/default-page.css
+++ b/inst/resources/css/default-page.css
@@ -26,7 +26,7 @@
   content: string(h1-text);
 }
 
-@page :left {
+@page chapter:left {
   @top-left {
     content: counter(page);
   }
@@ -49,7 +49,7 @@
   /* However, this is yet unsupported by Paged.js, see https://gitlab.pagedmedia.org/tools/pagedjs/issues/38 */
   content: string(h2-text);
 }
-@page :right {
+@page chapter:right {
   @top-right {
     content: counter(page);
   }
@@ -83,10 +83,44 @@
   }
 }
 
+/* Front matter*/
+@page frontmatter:left {
+  @top-left {
+    content: counter(page, lower-roman);
+  }
+  @top-right {
+    content: element(runningH1Title);
+    white-space: nowrap !important;
+  }
+}
+@page frontmatter:right {
+  @top-right {
+    content: counter(page, lower-roman);
+  }
+  @top-left {
+    content: element(runningH1Title);
+    white-space: nowrap !important;
+  }
+}
+@page frontmatter:first {
+  @top-left {
+    content: none;
+  }
+  @top-right {
+    content: none;
+  }
+  @bottom-right {
+    content: counter(page, lower-roman);
+  }
+}
+
 /* page breaks; aka CSS fragmentation */
 .level1 {
-  page: chapter;
   break-before: recto;
+  page: chapter;
+}
+.front-matter-container .level1 {
+  page: frontmatter;
 }
 h1, h2, h3, h4, h5, h6 {
   break-after: avoid;
@@ -97,4 +131,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 .figure {
   break-inside: avoid;
+}
+
+/* reset page numbering after front matter */
+.front-matter-container+.level1 h1 {
+  counter-reset: page;
 }

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -21,6 +21,9 @@ a[href^="http"]:not([class="uri"])::after {
 .main a[href^="#"]:not([class^="footnote-"]):not([href*=":"])::after {
   content: " (page " target-counter(attr(href), page) ")";
 }
+.main a.front-matter-ref[href^="#"]:not([class^="footnote-"]):not([href*=":"])::after {
+  content: " (page " target-counter(attr(href), page, lower-roman) ")";
+}
 
 /* TOC, LOT, LOF */
 .toc ul, .lot ul, .lof ul {
@@ -41,6 +44,10 @@ a[href^="http"]:not([class="uri"])::after {
   content: target-counter(attr(href), page);
   float: right;
   background: white;
+}
+.toc a.front-matter-ref::after, .lot a.front-matter-ref::after, .lof a.front-matter-ref::after {
+  /* content: leader(dotted) target-counter(attr(href), page, lower-roman); */
+  content: target-counter(attr(href), page, lower-roman);
 }
 .toc .leaders::before, .lot .leaders::before, .lof .leaders::before {
   float: left;

--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -131,11 +131,11 @@ $if(theme)$
 <div class="container-fluid main-container">
 $endif$
 
-<div class="front-matter-content">
 $for(include-before)$
 $include-before$
 $endfor$
 
+<div class="front-page">
 $if(title)$
 <div id="$idprefix$header" class="title-page">
 $if(shorttitle)$
@@ -170,7 +170,9 @@ $abstract$
 </div>
 $endif$
 $endif$
+</div>
 
+<div class="front-matter-container">
 $if(toc)$
 <div id="$idprefix$TOC" class="level1 toc front-matter">
 $if(toc-title)$
@@ -181,9 +183,7 @@ $table-of-contents$
 $endif$
 </div>
 
-<div class="main">
 $body$
-</div>
 
 $for(include-after)$
 $include-after$

--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -172,7 +172,7 @@ $endif$
 $endif$
 
 $if(toc)$
-<div id="$idprefix$TOC" class="level1 toc">
+<div id="$idprefix$TOC" class="level1 toc front-matter">
 $if(toc-title)$
 <h1 class="toc-title">$toc-title$</h1>
 $endif$

--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -131,7 +131,7 @@ $if(theme)$
 <div class="container-fluid main-container">
 $endif$
 
-<div class="front-matter">
+<div class="front-matter-content">
 $for(include-before)$
 $include-before$
 $endfor$

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -22,6 +22,18 @@
     }
   }
 
+  // This function adds the class front-matter-ref to any <a></a> element
+  // referring to an entry in the front matter
+  async function detectFrontMatterReferences() {
+    const frontMatter = document.querySelector('.front-matter-content');
+    let anchors = document.querySelectorAll('a[href^="#"]:not([href*=":"])');
+    for (let a of anchors) {
+      const ref = a.getAttribute('href');
+      const element = document.querySelector(ref);
+      if (frontMatter.contains(element)) a.classList.add('front-matter-ref');
+    }
+  }
+
   // This function expands the links in the lists of figures or tables (loft)
   async function expandLinksInLoft() {
     var items = document.querySelectorAll('.lof li, .lot li');
@@ -82,6 +94,7 @@
   window.PagedConfig = {
     before: async () => {
       await moveToFrontMatter();
+      await detectFrontMatterReferences();
       await expandLinksInLoft();
       await Promise.all([
         addLeadersSpans(),

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -13,9 +13,9 @@
 
   var runMathJax = getBeforeAsync();
 
-  // This function put the sections of class front-matter in the div.front-matter-content
+  // This function puts the sections of class front-matter in the div.front-matter-container
   async function moveToFrontMatter() {
-    let frontMatter = document.querySelector('.front-matter-content');
+    let frontMatter = document.querySelector('.front-matter-container');
     const items = document.querySelectorAll('.level1.front-matter');
     for (const item of items) {
       frontMatter.appendChild(item);
@@ -25,7 +25,7 @@
   // This function adds the class front-matter-ref to any <a></a> element
   // referring to an entry in the front matter
   async function detectFrontMatterReferences() {
-    const frontMatter = document.querySelector('.front-matter-content');
+    const frontMatter = document.querySelector('.front-matter-container');
     let anchors = document.querySelectorAll('a[href^="#"]:not([href*=":"])');
     for (let a of anchors) {
       const ref = a.getAttribute('href');

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -13,10 +13,10 @@
 
   var runMathJax = getBeforeAsync();
 
-  // This function put the LOT/LOF in the div.front-matter-content
+  // This function put the sections of class front-matter in the div.front-matter-content
   async function moveToFrontMatter() {
     let frontMatter = document.querySelector('.front-matter-content');
-    const items = document.querySelectorAll('.lof, .lot, .level1.front-matter');
+    const items = document.querySelectorAll('.level1.front-matter');
     for (const item of items) {
       frontMatter.appendChild(item);
     }

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -13,6 +13,15 @@
 
   var runMathJax = getBeforeAsync();
 
+  // This function put the LOT/LOF in the div.front-matter-content
+  async function moveToFrontMatter() {
+    let frontMatter = document.querySelector('.front-matter-content');
+    const items = document.querySelectorAll('.lof, .lot, .level1.front-matter');
+    for (const item of items) {
+      frontMatter.appendChild(item);
+    }
+  }
+
   // This function expands the links in the lists of figures or tables (loft)
   async function expandLinksInLoft() {
     var items = document.querySelectorAll('.lof li, .lot li');
@@ -72,6 +81,7 @@
 
   window.PagedConfig = {
     before: async () => {
+      await moveToFrontMatter();
       await expandLinksInLoft();
       await Promise.all([
         addLeadersSpans(),

--- a/inst/resources/lua/loft.lua
+++ b/inst/resources/lua/loft.lua
@@ -101,7 +101,7 @@ local function appendLoft(doc)
     lofHeader =
       pandoc.Header(1,
                     {table.unpack(options["lof-title"])},
-                    pandoc.Attr(idprefix .. "LOF", {"lof", "unnumbered"}, {})
+                    pandoc.Attr(idprefix .. "LOF", {"lof", "unnumbered", "front-matter"}, {})
       )
     table.insert(doc.blocks, 1, lofHeader)
   end
@@ -111,7 +111,7 @@ local function appendLoft(doc)
     lotHeader =
       pandoc.Header(1,
                     {table.unpack(options["lot-title"])},
-                    pandoc.Attr(idprefix .. "LOT", {"lot", "unnumbered"}, {})
+                    pandoc.Attr(idprefix .. "LOT", {"lot", "unnumbered", "front-matter"}, {})
       )
     table.insert(doc.blocks, 1, lotHeader)
   end


### PR DESCRIPTION
Here's a proposal to fix #1 (I need it for the CRC template).
The main points of this PR are the following:

1. Page numbers and `target-counter(attr(...), page)` generated contents need to be styled separately (see the [Paged.js spec](https://gitlab.pagedmedia.org/tools/pagedjs/blob/master/specs/issues/roman-numerals/roman-numerals.html)). 
1. The PR proposes to use the `front-matter` class to distinguish which sections belong to the front matter: I slightly modified the html template to create a specific `div.front-matter-container`.
1. This container is used to detect which elements belongs to the front matter and apply the correct style in the table of contents.

I also struggled with extra blank pages and finally found the solution by getting rid of the `div.main` element.

You can see the result in this [pdf file](https://github.com/rstudio/pagedown/files/2688466/pagedown.pdf).
