### PR TITLE
[business_card] Multiple business cards

### DIFF
--- a/R/card.R
+++ b/R/card.R
@@ -4,7 +4,6 @@
 #' \url{https://github.com/RelaxedJS/ReLaXed-examples}. See
 #' \url{https://pagedown.rbind.io/business-card/} for an example.
 #'
-#' @param logo Path or URL to a logo.
 #' @param width,height Width and height of the card.
 #' @param paperwidth,paperheight Width and height of the paper.
 #' @param cols,rows Number of columns and rows per page.
@@ -14,7 +13,7 @@
 #' @export
 #' @examples pagedown::business_card(googlefonts = 'Lato')
 business_card = function(
-  logo = NULL, width = '2in', height = '3in',
+  width = '2in', height = '3in',
   paperwidth = '2in', paperheight = '3in',
   cols = 1, rows = 1,
   googlefonts = 'Montserrat', mainfont = googlefonts

--- a/R/card.R
+++ b/R/card.R
@@ -15,8 +15,8 @@
 #' @examples pagedown::business_card(googlefonts = 'Lato')
 business_card = function(
   logo = NULL, width = '2in', height = '3in',
-  paperwidth = '8.5in', paperheight = '11in',
-  cols = 4, rows = 3,
+  paperwidth = '2in', paperheight = '3in',
+  cols = 1, rows = 1,
   googlefonts = 'Montserrat', mainfont = googlefonts
 ) {
   rmarkdown::output_format(

--- a/R/card.R
+++ b/R/card.R
@@ -4,31 +4,15 @@
 #' \url{https://github.com/RelaxedJS/ReLaXed-examples}. See
 #' \url{https://pagedown.rbind.io/business-card/} for an example.
 #'
-#' @param width,height Width and height of the card.
-#' @param paperwidth,paperheight Width and height of the paper.
-#' @param cols,rows Number of columns and rows per page.
-#' @param googlefonts Names of Google fonts to be loaded on the card page.
-#' @param mainfont Names of fonts to be used for the body text of the card.
 #' @return An R Markdown output format.
 #' @export
 #' @examples pagedown::business_card(googlefonts = 'Lato')
-business_card = function(
-  width = '2in', height = '3in',
-  paperwidth = '2in', paperheight = '3in',
-  cols = 1, rows = 1,
-  googlefonts = 'Montserrat', mainfont = googlefonts
-) {
+business_card = function() {
   rmarkdown::output_format(
     list(opts_chunk = list(echo = FALSE)),
     rmarkdown::pandoc_options('html', 'markdown', args = c(
       '--template', rmarkdown::pandoc_path_arg(pkg_resource('html', 'card.html')),
-      c(rbind('--variable', c(
-        paste0('googlefonts=', paste(googlefonts, collapse = '|')),
-        paste0('mainfont=', paste(mainfont, collapse = ', ')),
-        paste0('cardwidth=', width), paste0('cardheight=', height),
-        paste0('pagewidth=', paperwidth), paste0('pageheight=', paperheight),
-        paste0('ncols=', cols), paste0('nrows=', rows)
-      )))
+      '--variable', 'pagetitle=Business Card'
     ))
   )
 }

--- a/R/card.R
+++ b/R/card.R
@@ -20,7 +20,6 @@ business_card = function(
     rmarkdown::pandoc_options('html', 'markdown', args = c(
       '--template', rmarkdown::pandoc_path_arg(pkg_resource('html', 'card.html')),
       c(rbind('--variable', c(
-        paste0('logo=', logo),
         paste0('googlefonts=', paste(googlefonts, collapse = '|')),
         paste0('mainfont=', paste(mainfont, collapse = ', ')),
         paste0('pagewidth=', width), paste0('pageheight=', height)

--- a/R/card.R
+++ b/R/card.R
@@ -7,6 +7,7 @@
 #' @param logo Path or URL to a logo.
 #' @param width,height Width and height of the card.
 #' @param paperwidth,paperheight Width and height of the paper.
+#' @param cols,rows Number of columns and rows per page.
 #' @param googlefonts Names of Google fonts to be loaded on the card page.
 #' @param mainfont Names of fonts to be used for the body text of the card.
 #' @return An R Markdown output format.
@@ -15,6 +16,7 @@
 business_card = function(
   logo = NULL, width = '2in', height = '3in',
   paperwidth = '8.5in', paperheight = '11in',
+  cols = 4, rows = 3,
   googlefonts = 'Montserrat', mainfont = googlefonts
 ) {
   rmarkdown::output_format(
@@ -25,7 +27,8 @@ business_card = function(
         paste0('googlefonts=', paste(googlefonts, collapse = '|')),
         paste0('mainfont=', paste(mainfont, collapse = ', ')),
         paste0('cardwidth=', width), paste0('cardheight=', height),
-        paste0('pagewidth=', paperwidth), paste0('pageheight=', paperheight)
+        paste0('pagewidth=', paperwidth), paste0('pageheight=', paperheight),
+        paste0('ncols=', cols), paste0('nrows=', rows)
       )))
     ))
   )

--- a/R/card.R
+++ b/R/card.R
@@ -6,7 +6,7 @@
 #'
 #' @return An R Markdown output format.
 #' @export
-#' @examples pagedown::business_card(googlefonts = 'Lato')
+#' @examples pagedown::business_card()
 business_card = function() {
   rmarkdown::output_format(
     list(opts_chunk = list(echo = FALSE)),

--- a/R/card.R
+++ b/R/card.R
@@ -6,6 +6,7 @@
 #'
 #' @param logo Path or URL to a logo.
 #' @param width,height Width and height of the card.
+#' @param paperwidth,paperheight Width and height of the paper.
 #' @param googlefonts Names of Google fonts to be loaded on the card page.
 #' @param mainfont Names of fonts to be used for the body text of the card.
 #' @return An R Markdown output format.
@@ -13,6 +14,7 @@
 #' @examples pagedown::business_card(googlefonts = 'Lato')
 business_card = function(
   logo = NULL, width = '2in', height = '3in',
+  paperwidth = '8.5in', paperheight = '11in',
   googlefonts = 'Montserrat', mainfont = googlefonts
 ) {
   rmarkdown::output_format(
@@ -22,7 +24,8 @@ business_card = function(
       c(rbind('--variable', c(
         paste0('googlefonts=', paste(googlefonts, collapse = '|')),
         paste0('mainfont=', paste(mainfont, collapse = ', ')),
-        paste0('pagewidth=', width), paste0('pageheight=', height)
+        paste0('cardwidth=', width), paste0('cardheight=', height),
+        paste0('pagewidth=', paperwidth), paste0('pageheight=', paperheight)
       )))
     ))
   )

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -238,6 +238,98 @@ We do not have time to document the poster formats yet, but here is a caveat: th
 
 To create a simple business card, you can use the `pagedown::business_card` format. See https://pagedown.rbind.io/business-card/ for an example.
 
+### Single card
+
+A single business card can be created with the following YAML header.
+
+```yaml
+---
+name: Jane Doe
+title: Miss Nobody
+phone: "+1 123-456-7890"
+email: "jane.doe@example.com"
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+output: pagedown::business_card
+---
+```
+
+You can repeat the card on multiple pages using the `repeat` variable. The following example produces as many pages as cards (12).
+
+```yaml
+---
+name: Jane Doe
+title: Miss Nobody
+phone: "+1 123-456-7890"
+email: "jane.doe@example.com"
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+repeat: 12
+output: pagedown::business_card
+---
+```
+
+In order to print the cards, you may prefer a layout with several cards on the same page: you can adjust the paper size with the `paperwidth` and `paperheight` variables and define a grid layout with the `cols` and `rows` variables.
+
+```yaml
+---
+name: Jane Doe
+title: Miss Nobody
+phone: "+1 123-456-7890"
+email: "jane.doe@example.com"
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+repeat: 12
+output: 
+  pagedown::business_card:
+    cols: 4
+    rows: 3
+    paperwidth: 8.5in
+    paperheight: 11in
+---
+```
+
+### Different cards with shared informations
+
+You can produce business cards for members of an organization sharing some informations (address, website...).  
+Common informations are declared as top level variables in the YAML header. Custom cards are defined using the `person` variable.
+
+```yaml
+---
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+person:
+  - name: Jane Doe
+    title: Miss Nobody
+    phone: "+1 123-456-7890"
+    email: "jane.doe@example.com"
+    repeat: 6
+  - name: John Doe
+    title: Mister Nobody
+    phone: "+1 777-777-7777"
+    email: "john.doe@example.com"
+    repeat: 6
+output: 
+  pagedown::business_card:
+    cols: 4
+    rows: 3
+    paperwidth: 8.5in
+    paperheight: 11in
+---
+```
+
 ## Letter
 
 You can write a letter with the `pagedown::html_letter` format. See https://pagedown.rbind.io/html-letter/ for an example.

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -240,7 +240,7 @@ To create a simple business card, you can use the `pagedown::business_card` form
 
 ### Single card
 
-A single business card can be created with the following YAML header.
+A single business card can be created with the following R Markdown file (this file contains only a YAML header).
 
 ```yaml
 ---
@@ -275,7 +275,7 @@ output: pagedown::business_card
 ---
 ```
 
-In order to print the cards, you may prefer a layout with several cards on the same page: you can adjust the paper size with the `paperwidth` and `paperheight` variables and define a grid layout with the `cols` and `rows` variables.
+In order to print the cards, you may prefer a layout with several cards on the same page: you can adjust the paper size with the `paperwidth` and `paperheight` variables and define a grid layout with the `cols` and `rows` variables (you may test some combinations of these parameters to find the most appropriate one).
 
 ```yaml
 ---
@@ -289,22 +289,48 @@ address: |
   Sunshine, CA 90000
 logo: "logo.png"
 repeat: 12
-output: 
-  pagedown::business_card:
-    cols: 4
-    rows: 3
-    paperwidth: 8.5in
-    paperheight: 11in
+paperwidth: 8.5in
+paperheight: 11in
+cols: 4
+rows: 3
+output: pagedown::business_card
 ---
+```
+
+You also can use markdown to define a card. Be aware to use the `slot` attributes as follows.
+
+```markdown
+---
+logo: "logo.png"
+paperwidth: 8.5in
+paperheight: 11in
+cols: 4
+rows: 3
+output: pagedown::business_card
+---
+
+::::: {.wrapper data-repeat="12"}
+[Jane Doe]{slot="name"}
+[Miss Nobody]{slot="title"}
+[+1 123-456-7890]{slot="phone"}
+[jane.doe@example.com]{slot="email"}
+[www.example.com]{slot="url"}
+
+::: {.address slot="address"}
+2020 South Street
+Sunshine, CA 90000
+:::
+:::::
 ```
 
 ### Different cards with shared informations
 
 You can produce business cards for members of an organization sharing some informations (address, website...).  
-Common informations are declared as top level variables in the YAML header. Custom cards are defined using the `person` variable.
+Common informations are declared as top level variables in the YAML header. Custom cards are defined using the `person` variable: each `key: value` pair of a `person` block overrides the corresponding top level pair.
 
 ```yaml
 ---
+phone: "+1 123-456-7890"
 url: www.example.com
 address: |
   2020 South Street
@@ -313,33 +339,167 @@ logo: "logo.png"
 person:
   - name: Jane Doe
     title: Miss Nobody
-    phone: "+1 123-456-7890"
     email: "jane.doe@example.com"
     repeat: 6
   - name: John Doe
     title: Mister Nobody
-    phone: "+1 777-777-7777"
+    phone: "+1 777-777-7777" # overrides the default phone
     email: "john.doe@example.com"
     repeat: 6
-output: 
-  pagedown::business_card:
-    cols: 4
-    rows: 3
-    paperwidth: 8.5in
-    paperheight: 11in
+paperwidth: 8.5in
+paperheight: 11in
+cols: 4
+rows: 3
+output: pagedown::business_card
 ---
 ```
 
 If you prefer, you can use markdown to create a card as follows.
 
 ```markdown
+---
+name: Jane Doe
+title: Miss Nobody
+phone: "+1 123-456-7890"
+email: "jane.doe@example.com"
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+repeat: 6
+paperwidth: 8.5in
+paperheight: 11in
+cols: 4
+rows: 3
+output: pagedown::business_card
+---
+
 ::: {.wrapper data-repeat="6"}
 [John Doe]{slot="name"}
 [Mister Nobody]{slot="title"}
-[john.doe@example.com]{slot="email"}
 [+1 777-777-7777]{slot="phone"}
+[john.doe@example.com]{slot="email"}
+[my.domain.com]{slot="url"}
 :::
 ```
+
+### Styling business cards
+
+#### Fonts
+
+You can change the text font with the `mainfont` and/or `googlefonts` top level YAML variables:
+
+- `mainfont` will use the local font installed on your computer, e.g.
+  ```yaml
+  ---
+  name: Jane Doe
+  title: Miss Nobody
+  phone: "+1 123-456-7890"
+  email: "jane.doe@example.com"
+  url: www.example.com
+  address: |
+    2020 South Street
+    Sunshine, CA 90000
+  logo: "logo.png"
+  mainfont: Arial
+  output: pagedown::business_card
+  ---
+  ```
+
+- `googlefonts` to use fonts from https://fonts.google.com, e.g.
+  ```yaml
+  ---
+  name: Jane Doe
+  title: Miss Nobody
+  phone: "+1 123-456-7890"
+  email: "jane.doe@example.com"
+  url: www.example.com
+  address: |
+    2020 South Street
+    Sunshine, CA 90000
+  logo: "logo.png"
+  googlefonts: ["Roboto Condensed", "Raleway"]
+  output: pagedown::business_card
+  ---
+  ```
+
+#### Card sizing
+
+You can modify the card size with the `cardwidth` and `cardheight` variables. You can get a landscape card with:
+
+```yaml
+---
+name: Jane Doe
+title: Miss Nobody
+phone: "+1 123-456-7890"
+email: "jane.doe@example.com"
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+cardwidth: 3.5in
+cardheight: 2in
+output: pagedown::business_card
+---
+```
+
+If you render this card, you will see that the default style does not suit well with a landscape card. Read the next section to find an example of a landscape card with a better style.
+
+#### CSS
+
+Finally, you can modify the style of the card using CSS rules.  
+The markup of a card can be represented as follows^[This is technically incorrect since the card template use a shadow DOM.]:
+
+```html
+<div class="wrapper" data-repeat="1">
+  <img class="logo" src="logo.png" alt="Logo" />
+  <div class="me">
+    <div class="name"><span>Jane Doe</span></div>
+    <div class="title"><span>Miss Nobody</span></div>
+    <div class="coordinates">
+      <p class="phone"><span>+1 123-456-7890</span></p>
+      <p class="contact-email"><span>jane.doe@example.com</span></p>
+      <p class="website"><span>www.example.com</span></p>
+      <div class="address">2020 South Street Sunshine, CA 90000</div>
+    </div>
+  </div>
+</div>
+```
+
+You can use these built-in classes to style your card with CSS.  
+A landscape card could be styled like this:
+
+~~~markdown
+---
+name: Jane Doe
+title: Miss Nobody
+phone: "+1 123-456-7890"
+email: "jane.doe@example.com"
+url: www.example.com
+address: |
+  2020 South Street
+  Sunshine, CA 90000
+logo: "logo.png"
+cardwidth: 3.5in
+cardheight: 2in
+output: pagedown::business_card
+---
+
+`r ''````{css}
+.logo {
+  display: block;
+  height: 20%;
+  margin-right: .3in;
+  padding: .3in 0 0;
+  float: right;
+}
+.name {
+  margin-top: .1in;
+}
+```
+~~~
 
 ## Letter
 

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -330,6 +330,17 @@ output:
 ---
 ```
 
+If you prefer, you can use markdown to create a card as follows.
+
+```markdown
+::: {.wrapper data-repeat="6"}
+[John Doe]{slot="name"}
+[Mister Nobody]{slot="title"}
+[john.doe@example.com]{slot="email"}
+[+1 777-777-7777]{slot="phone"}
+:::
+```
+
 ## Letter
 
 You can write a letter with the `pagedown::html_letter` format. See https://pagedown.rbind.io/html-letter/ for an example.

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -20,12 +20,19 @@
     margin: 0;
     padding: 0;
   }
+  .wrapper {
+    font-family: $if(mainfont)$$mainfont$, $endif$sans-serif;
+    color: white;
+    background-color: black;
+    width: $pagewidth$;
+    height: $pageheight$;
+    margin: auto;
+  }
   </style>
 </head>
 
 <body>
   <template id="card-template">
-  <div class="wrapper">
   $if(logo)$<img class="logo" src="$logo$" alt="Logo" />$endif$
   <div class="me">
     <div class="name"><slot name="name">$name$</slot></div>
@@ -37,16 +44,7 @@
       <slot name="address">$address$</slot>
     </div>
   </div>
-  </div>
   <style>
-  .wrapper {
-    font-family: $if(mainfont)$$mainfont$, $endif$sans-serif;
-    color: white;
-    background-color: black;
-    width: $pagewidth$;
-    height: $pageheight$;
-    margin: auto;
-  }
   .logo {
     display: block;
     width: 75%;
@@ -70,41 +68,47 @@
   </style>
   </template>
 
-  $if(name)$
-  <div class="card">
-    <span slot="name">$name$</span>
-    $if(title)$<span slot="title">$title$</span>$endif$
-    $if(phone)$<span slot="phone">$phone$</span>$endif$
-    $if(email)$<span slot="email">$email$</span>$endif$
-    $if(url)$<span slot="url">$url$</span>$endif$
-    $if(address)$<div slot="address">$address$</div>$endif$
-  </div>
-  $endif$
-
-  $for(person)$
-  <div class="card">
-    $if(person.name)$
-    <span slot="name">$person.name$</span>
-    $else$
-    <span slot="name">$person$</span>
+  <div class="wrapper">
+    $if(name)$
+    <div class="card">
+      <span slot="name">$name$</span>
+      $if(title)$<span slot="title">$title$</span>$endif$
+      $if(phone)$<span slot="phone">$phone$</span>$endif$
+      $if(email)$<span slot="email">$email$</span>$endif$
+      $if(url)$<span slot="url">$url$</span>$endif$
+      $if(address)$<div slot="address">$address$</div>$endif$
+    </div>
     $endif$
-    $if(person.title)$<span slot="title">$person.title$</span>$endif$
-    $if(person.phone)$<span slot="phone">$person.phone$</span>$endif$
-    $if(person.email)$<span slot="email">$person.email$</span>$endif$
-    $if(person.url)$<span slot="url">$person.url$</span>$endif$
-    $if(person.address)$<div slot="address">$person.address$</div>$endif$
-  </div>
-  $endfor$
+
+    $for(person)$
+    <div class="card">
+      $if(person.name)$
+      <span slot="name">$person.name$</span>
+      $else$
+      <span slot="name">$person$</span>
+      $endif$
+      $if(person.title)$<span slot="title">$person.title$</span>$endif$
+      $if(person.phone)$<span slot="phone">$person.phone$</span>$endif$
+      $if(person.email)$<span slot="email">$person.email$</span>$endif$
+      $if(person.url)$<span slot="url">$person.url$</span>$endif$
+      $if(person.address)$<div slot="address">$person.address$</div>$endif$
+    </div>
+    $endfor$
 
   $body$
+  </div>
 
   <script>
     (() => {
       let templateContent = document.getElementById('card-template').content;
       let cards = document.querySelectorAll('.card');
+      let styles = document.querySelectorAll('.wrapper style');
       for (let card of cards) {
-        card.attachShadow({  mode: 'open' })
-            .appendChild(templateContent.cloneNode(true))
+        let shadow = card.attachShadow({  mode: 'open' });
+        shadow.appendChild(templateContent.cloneNode(true));
+        for (let style of styles) {
+          shadow.innerHTML += '<style>' + style.innerHTML + '</style>';
+        }
       }
     })();
   </script>

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -108,15 +108,23 @@
   </div>
   $endfor$
 
-  <div class="extra-content">
   $body$
-  </div>
 
   <script>
     (() => {
+      // when a card is created in markdown, spans are embedded in paragraphs
+      // we need to move these spans outside paragraph to be detected by the template
+      let paragraphs = document.querySelectorAll('.wrapper > p');
+      for (let paragraph of paragraphs) {
+        let wrapper = paragraph.parentElement;
+        for (let element of paragraph.childNodes) {
+          wrapper.appendChild(element);
+        }
+      }
+
+      // repeat cards
       const maxItemsPerGrid = $ncols$ * $nrows$;
       let cards = document.querySelectorAll('.wrapper');
-      // repeat cards
       for (const card of cards) {
         for (let i = 1; i < card.dataset.repeat; i++) {
           document.body.insertBefore(card.cloneNode(true), card);
@@ -139,7 +147,7 @@
 
       // build the shadow DOM for each card
       let templateContent = document.getElementById('card-template').content;
-      let styles = document.querySelectorAll('.extra-content style');
+      let styles = document.querySelectorAll('body > style');
       for (let card of cards) {
         let shadowDOM = card.attachShadow({  mode: 'open' });
         shadowDOM.appendChild(templateContent.cloneNode(true));

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -20,6 +20,25 @@
     margin: 0;
     padding: 0;
   }
+  </style>
+</head>
+
+<body>
+  <template id="card-template">
+  <div class="wrapper">
+  $if(logo)$<img class="logo" src="$logo$" alt="Logo" />$endif$
+  <div class="me">
+    <div class="name"><slot name="name">$name$</slot></div>
+    <div class="title"><slot name="title">$title$</slot></div>
+    <div class="coordinates">
+      <p><slot name="phone">$phone$</slot></p>
+      <p><slot name="email">$email$</slot></p>
+      <p><slot name="url">$url$</slot></p>
+      <slot name="address">$address$</slot>
+    </div>
+  </div>
+  </div>
+  <style>
   .wrapper {
     font-family: $if(mainfont)$$mainfont$, $endif$sans-serif;
     color: white;
@@ -49,18 +68,46 @@
     line-height: 1em;
   }
   </style>
-</head>
+  </template>
 
-<body>
-  <div class="wrapper">
-  $if(logo)$<img class="logo" src="$logo$" alt="Logo" />$endif$
-  <div class="me">
-    <div class="name">$author$</div>
-    <div class="title">$title$</div>
-    <div class="coordinates">
-      $body$
-    </div>
+  $if(name)$
+  <div class="card">
+    <span slot="name">$name$</span>
+    $if(title)$<span slot="title">$title$</span>$endif$
+    $if(phone)$<span slot="phone">$phone$</span>$endif$
+    $if(email)$<span slot="email">$email$</span>$endif$
+    $if(url)$<span slot="url">$url$</span>$endif$
+    $if(address)$<div slot="address">$address$</div>$endif$
   </div>
+  $endif$
+
+  $for(person)$
+  <div class="card">
+    $if(person.name)$
+    <span slot="name">$person.name$</span>
+    $else$
+    <span slot="name">$person$</span>
+    $endif$
+    $if(person.title)$<span slot="title">$person.title$</span>$endif$
+    $if(person.phone)$<span slot="phone">$person.phone$</span>$endif$
+    $if(person.email)$<span slot="email">$person.email$</span>$endif$
+    $if(person.url)$<span slot="url">$person.url$</span>$endif$
+    $if(person.address)$<div slot="address">$person.address$</div>$endif$
   </div>
+  $endfor$
+
+  $body$
+
+  <script>
+    (() => {
+      let templateContent = document.getElementById('card-template').content;
+      let cards = document.querySelectorAll('.card');
+      for (let card of cards) {
+        card.attachShadow({  mode: 'open' })
+            .appendChild(templateContent.cloneNode(true))
+      }
+    })();
+  </script>
+
 </body>
 </html>

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -112,8 +112,8 @@
 
   <script>
     (() => {
-      // when a card is created in markdown, spans are embedded in paragraphs
-      // we need to move these spans outside paragraph to be detected by the template
+      // when a card is created using markdown, Pandoc embeds spans in paragraphs
+      // we need to move these spans outside paragraphs to be detected by the template
       let paragraphs = document.querySelectorAll('.wrapper > p');
       for (let paragraph of paragraphs) {
         let wrapper = paragraph.parentElement;

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -38,6 +38,15 @@
     color: white;
     background-color: black;
   }
+  @media screen {
+    html, body {
+      width: 100%;
+      height: 100%;
+    }
+    .grid {
+      margin: auto;
+    }
+  }
   </style>
 </head>
 

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -19,14 +19,17 @@
   html, body {
     margin: 0;
     padding: 0;
-  }
-  body {
     width: $pagewidth$;
     height: $pageheight$;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-content: space-around;
+  }
+  .grid {
+    display: grid;
+    width: $pagewidth$;
+    height: $pageheight$;
+    grid-template-columns: repeat($ncols$, calc(100% / $ncols$));
+    grid-template-rows: repeat($nrows$, calc(100% / $nrows$));
+    justify-items: center;
+    align-items: center;
   }
   .wrapper {
     box-sizing: border-box;
@@ -34,7 +37,6 @@
     height: $cardheight$;
     color: white;
     background-color: black;
-    flex-shrink: 0;
   }
   </style>
 </head>
@@ -105,8 +107,24 @@
 
   <script>
     (() => {
-      let templateContent = document.getElementById('card-template').content;
+      const maxItemsPerGrid = $ncols$ * $nrows$;
       let wrappers = document.querySelectorAll('.wrapper');
+      let wrappersArray = Array.from(wrappers);
+
+      // split the cards into grids
+      while (wrappersArray.length > 0) {
+        const numberOfItemsToInsertInGrid = Math.min(maxItemsPerGrid, wrappersArray.length);
+        let container = document.createElement('div');
+        container.className = 'grid';
+        document.body.insertBefore(container, wrappersArray[0]);
+        for (let wrapper of wrappersArray.slice(0, numberOfItemsToInsertInGrid)) {
+          container.appendChild(wrapper);
+        }
+        wrappersArray.splice(0, numberOfItemsToInsertInGrid);
+      }
+
+      // build the shadow DOM for each wrapper
+      let templateContent = document.getElementById('card-template').content;
       let styles = document.querySelectorAll('.extra-content style');
       for (let wrapper of wrappers) {
         let shadowDOM = wrapper.attachShadow({  mode: 'open' });
@@ -115,6 +133,7 @@
           shadowDOM.innerHTML += '<style>' + style.innerHTML + '</style>';
         }
       }
+
     })();
   </script>
 

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -20,13 +20,21 @@
     margin: 0;
     padding: 0;
   }
-  .wrapper {
-    font-family: $if(mainfont)$$mainfont$, $endif$sans-serif;
-    color: white;
-    background-color: black;
+  body {
     width: $pagewidth$;
     height: $pageheight$;
-    margin: auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-content: space-around;
+  }
+  .wrapper {
+    box-sizing: border-box;
+    width: $cardwidth$;
+    height: $cardheight$;
+    color: white;
+    background-color: black;
+    flex-shrink: 0;
   }
   </style>
 </head>
@@ -35,13 +43,13 @@
   <template id="card-template">
   $if(logo)$<img class="logo" src="$logo$" alt="Logo" />$endif$
   <div class="me">
-    <div class="name"><slot name="name">$name$</slot></div>
-    <div class="title"><slot name="title">$title$</slot></div>
+    <div class="name"><slot name="name"><span>$name$</span></slot></div>
+    <div class="title"><slot name="title"><span>$title$</span></slot></div>
     <div class="coordinates">
-      <p><slot name="phone">$phone$</slot></p>
-      <p><slot name="email">$email$</slot></p>
-      <p><slot name="url">$url$</slot></p>
-      <slot name="address">$address$</slot>
+      <p><slot name="phone"><span>$phone$</span></slot></p>
+      <p><slot name="email"><span>$email$</span></slot></p>
+      <p><slot name="url"><span>$url$</span></slot></p>
+      <slot name="address"><div>$address$</div></slot>
     </div>
   </div>
   <style>
@@ -52,6 +60,7 @@
     padding: .3in 0 0;
   }
   .me {
+    font-family: $if(mainfont)$$mainfont$, $endif$sans-serif;
     font-size: 11px;
     letter-spacing: 0.8px;
     line-height: 1.7em;
@@ -68,46 +77,42 @@
   </style>
   </template>
 
+  $if(name)$
   <div class="wrapper">
-    $if(name)$
-    <div class="card">
-      <span slot="name">$name$</span>
-      $if(title)$<span slot="title">$title$</span>$endif$
-      $if(phone)$<span slot="phone">$phone$</span>$endif$
-      $if(email)$<span slot="email">$email$</span>$endif$
-      $if(url)$<span slot="url">$url$</span>$endif$
-      $if(address)$<div slot="address">$address$</div>$endif$
-    </div>
+  </div>
+  $endif$
+
+  $for(person)$
+
+  <div class="wrapper">
+    $if(person.name)$
+    <span slot="name">$person.name$</span>
+    $else$
+    <span slot="name">$person$</span>
     $endif$
+    $if(person.title)$<span slot="title">$person.title$</span>$endif$
+    $if(person.phone)$<span slot="phone">$person.phone$</span>$endif$
+    $if(person.email)$<span slot="email">$person.email$</span>$endif$
+    $if(person.url)$<span slot="url">$person.url$</span>$endif$
+    $if(person.address)$<div slot="address">$person.address$</div>$endif$
+  </div>
 
-    $for(person)$
-    <div class="card">
-      $if(person.name)$
-      <span slot="name">$person.name$</span>
-      $else$
-      <span slot="name">$person$</span>
-      $endif$
-      $if(person.title)$<span slot="title">$person.title$</span>$endif$
-      $if(person.phone)$<span slot="phone">$person.phone$</span>$endif$
-      $if(person.email)$<span slot="email">$person.email$</span>$endif$
-      $if(person.url)$<span slot="url">$person.url$</span>$endif$
-      $if(person.address)$<div slot="address">$person.address$</div>$endif$
-    </div>
-    $endfor$
+  $endfor$
 
+  <div class="extra-content">
   $body$
   </div>
 
   <script>
     (() => {
       let templateContent = document.getElementById('card-template').content;
-      let cards = document.querySelectorAll('.card');
-      let styles = document.querySelectorAll('.wrapper style');
-      for (let card of cards) {
-        let shadow = card.attachShadow({  mode: 'open' });
-        shadow.appendChild(templateContent.cloneNode(true));
+      let wrappers = document.querySelectorAll('.wrapper');
+      let styles = document.querySelectorAll('.extra-content style');
+      for (let wrapper of wrappers) {
+        let shadowDOM = wrapper.attachShadow({  mode: 'open' });
+        shadowDOM.appendChild(templateContent.cloneNode(true));
         for (let style of styles) {
-          shadow.innerHTML += '<style>' + style.innerHTML + '</style>';
+          shadowDOM.innerHTML += '<style>' + style.innerHTML + '</style>';
         }
       }
     })();

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -9,7 +9,7 @@
   <meta name="author" content="$author-meta$" />
   <title>$if(title-prefix)$$title-prefix$ - $endif$$author-meta$: $pagetitle$</title>
   $if(googlefonts)$
-  <link href="https://fonts.googleapis.com/css?family=$googlefonts$" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=$googlefonts$" rel="stylesheet" />
   $endif$
   <style>
   @page {
@@ -89,13 +89,12 @@
   </template>
 
   $if(name)$
-  <div class="wrapper">
+  <div class="wrapper" data-repeat="$if(repeat)$$repeat$$else$1$endif$">
   </div>
   $endif$
 
   $for(person)$
-
-  <div class="wrapper">
+  <div class="wrapper" data-repeat="$if(person.repeat)$$person.repeat$$else$1$endif$">
     $if(person.name)$
     <span slot="name">$person.name$</span>
     $else$
@@ -107,7 +106,6 @@
     $if(person.url)$<span slot="url">$person.url$</span>$endif$
     $if(person.address)$<div slot="address">$person.address$</div>$endif$
   </div>
-
   $endfor$
 
   <div class="extra-content">
@@ -117,34 +115,39 @@
   <script>
     (() => {
       const maxItemsPerGrid = $ncols$ * $nrows$;
-      let wrappers = document.querySelectorAll('.wrapper');
-      let wrappersArray = Array.from(wrappers);
-
-      // split the cards into grids
-      while (wrappersArray.length > 0) {
-        const numberOfItemsToInsertInGrid = Math.min(maxItemsPerGrid, wrappersArray.length);
-        let container = document.createElement('div');
-        container.className = 'grid';
-        document.body.insertBefore(container, wrappersArray[0]);
-        for (let wrapper of wrappersArray.slice(0, numberOfItemsToInsertInGrid)) {
-          container.appendChild(wrapper);
+      let cards = document.querySelectorAll('.wrapper');
+      // repeat cards
+      for (const card of cards) {
+        for (let i = 1; i < card.dataset.repeat; i++) {
+          document.body.insertBefore(card.cloneNode(true), card);
         }
-        wrappersArray.splice(0, numberOfItemsToInsertInGrid);
       }
 
-      // build the shadow DOM for each wrapper
+      // spread the cards in grids
+      cards = document.querySelectorAll('.wrapper');
+      let cardsArray = Array.from(cards);
+      while (cardsArray.length > 0) {
+        const numberOfItemsToInsertInGrid = Math.min(maxItemsPerGrid, cardsArray.length);
+        let grid = document.createElement('div');
+        grid.className = 'grid';
+        document.body.insertBefore(grid, cardsArray[0]);
+        for (let card of cardsArray.slice(0, numberOfItemsToInsertInGrid)) {
+          grid.appendChild(card);
+        }
+        cardsArray.splice(0, numberOfItemsToInsertInGrid);
+      }
+
+      // build the shadow DOM for each card
       let templateContent = document.getElementById('card-template').content;
       let styles = document.querySelectorAll('.extra-content style');
-      for (let wrapper of wrappers) {
-        let shadowDOM = wrapper.attachShadow({  mode: 'open' });
+      for (let card of cards) {
+        let shadowDOM = card.attachShadow({  mode: 'open' });
         shadowDOM.appendChild(templateContent.cloneNode(true));
         for (let style of styles) {
           shadowDOM.innerHTML += '<style>' + style.innerHTML + '</style>';
         }
       }
-
     })();
   </script>
-
 </body>
 </html>

--- a/inst/resources/html/card.html
+++ b/inst/resources/html/card.html
@@ -7,34 +7,32 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="author" content="$author-meta$" />
-  <title>$if(title-prefix)$$title-prefix$ - $endif$$author-meta$: $pagetitle$</title>
-  $if(googlefonts)$
-  <link href="https://fonts.googleapis.com/css?family=$googlefonts$" rel="stylesheet" />
-  $endif$
+  <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
+  <link href="https://fonts.googleapis.com/css?family=$if(googlefonts)$$for(googlefonts)$$googlefonts$$sep$|$endfor$$else$Montserrat$endif$" rel="stylesheet" />
   <style>
   @page {
     margin: 0;
-    size: $pagewidth$ $pageheight$;
+    size: $if(paperwidth)$$paperwidth$$else$$if(cardwidth)$$cardwidth$$else$2in$endif$$endif$ $if(paperheight)$$paperheight$$else$$if(cardheight)$$cardheight$$else$3in$endif$$endif$;
   }
   html, body {
     margin: 0;
     padding: 0;
-    width: $pagewidth$;
-    height: $pageheight$;
+    width: $if(paperwidth)$$paperwidth$$else$$if(cardwidth)$$cardwidth$$else$2in$endif$$endif$;
+    height: $if(paperheight)$$paperheight$$else$$if(cardheight)$$cardheight$$else$3in$endif$$endif$;
   }
   .grid {
     display: grid;
-    width: $pagewidth$;
-    height: $pageheight$;
-    grid-template-columns: repeat($ncols$, calc(100% / $ncols$));
-    grid-template-rows: repeat($nrows$, calc(100% / $nrows$));
+    width: $if(paperwidth)$$paperwidth$$else$$if(cardwidth)$$cardwidth$$else$2in$endif$$endif$;
+    height: $if(paperheight)$$paperheight$$else$$if(cardheight)$$cardheight$$else$3in$endif$$endif$;
+    grid-template-columns: repeat($if(cols)$$cols$$else$1$endif$, calc(100% / $if(cols)$$cols$$else$1$endif$));
+    grid-template-rows: repeat($if(rows)$$rows$$else$1$endif$, calc(100% / $if(rows)$$rows$$else$1$endif$));
     justify-items: center;
     align-items: center;
   }
   .wrapper {
     box-sizing: border-box;
-    width: $cardwidth$;
-    height: $cardheight$;
+    width: $if(cardwidth)$$cardwidth$$else$2in$endif$;
+    height: $if(cardheight)$$cardheight$$else$3in$endif$;
     color: white;
     background-color: black;
   }
@@ -57,21 +55,21 @@
     <div class="name"><slot name="name"><span>$name$</span></slot></div>
     <div class="title"><slot name="title"><span>$title$</span></slot></div>
     <div class="coordinates">
-      <p><slot name="phone"><span>$phone$</span></slot></p>
-      <p><slot name="email"><span>$email$</span></slot></p>
-      <p><slot name="url"><span>$url$</span></slot></p>
-      <slot name="address"><div>$address$</div></slot>
+      <p class="phone"><slot name="phone"><span>$phone$</span></slot></p>
+      <p class="contact-email"><slot name="email"><span>$email$</span></slot></p>
+      <p class="website"><slot name="url"><span>$url$</span></slot></p>
+      <slot name="address"><div class="address">$address$</div></slot>
     </div>
   </div>
   <style>
   .logo {
     display: block;
-    width: 75%;
+    max-width: 75%;
     margin: auto;
     padding: .3in 0 0;
   }
   .me {
-    font-family: $if(mainfont)$$mainfont$, $endif$sans-serif;
+    font-family: $if(mainfont)$$for(mainfont)$'$mainfont$'$sep$, $endfor$, $else$$if(googlefonts)$$for(googlefonts)$'$googlefonts$'$sep$, $endfor$, $else$'Montserrat', $endif$$endif$sans-serif;
     font-size: 11px;
     letter-spacing: 0.8px;
     line-height: 1.7em;
@@ -104,7 +102,7 @@
     $if(person.phone)$<span slot="phone">$person.phone$</span>$endif$
     $if(person.email)$<span slot="email">$person.email$</span>$endif$
     $if(person.url)$<span slot="url">$person.url$</span>$endif$
-    $if(person.address)$<div slot="address">$person.address$</div>$endif$
+    $if(person.address)$<div slot="address" class="address">$person.address$</div>$endif$
   </div>
   $endfor$
 
@@ -123,7 +121,7 @@
       }
 
       // repeat cards
-      const maxItemsPerGrid = $ncols$ * $nrows$;
+      const maxItemsPerGrid = $if(cols)$$cols$$else$1$endif$ * $if(rows)$$rows$$else$1$endif$;
       let cards = document.querySelectorAll('.wrapper');
       for (const card of cards) {
         for (let i = 1; i < card.dataset.repeat; i++) {

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -22,6 +22,14 @@ output:
     # googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
 ---
 
+<!-- if you prefer you can create cards in markdown instead of YAML declaration -->
+
+::: {.wrapper data-repeat="12"}
+[Another Name]{slot="name"}
+[Another Title]{slot="title"}
+[someone@rstudio.com]{slot="email"}
+:::
+
 
 <!-- if you prefer black text on white background, set eval=TRUE on the chunk below -->
 

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -1,17 +1,24 @@
 ---
 logo: "https://www.rstudio.com/wp-content/uploads/2016/09/RStudio-Logo-Blue-Gray-250.png"
-name: "Tareef Kawaf"
-title: "President of RStudio, Inc."
 phone: "+1 844-448-1212"
 email: "info@rstudio.com"
 url: www.rstudio.com
 address: |
   @rstudio
-#person: 
-#  - name: Yihui Xie
-#    title: Responsible for `r grep('(?<!shut)down$', rownames(installed.packages()), value=T, perl=T)`
+person: 
+  - name: Tareef Kawaf
+    title: President of RStudio, Inc.
+    repeat: 6
+  - name: Yihui Xie
+    title: Responsible for `r grep('(?<!shut)down$', unique(rownames(installed.packages())), value=T, perl=T)`
+    repeat: 6
+  - Jane Doe
 output:
-  pagedown::business_card: default
+  pagedown::business_card: 
+    cols: 4
+    rows: 3
+    paperwidth: 8.5in
+    paperheight: 11in
     # googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
 ---
 

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -7,9 +7,9 @@ email: "info@rstudio.com"
 url: www.rstudio.com
 address: |
   @rstudio
-person: 
-  - name: Yihui Xie
-    title: Responsible for `r grep('(?<!shut)down$', rownames(installed.packages()), value=T, perl=T)`
+#person: 
+#  - name: Yihui Xie
+#    title: Responsible for `r grep('(?<!shut)down$', rownames(installed.packages()), value=T, perl=T)`
 output:
   pagedown::business_card: default
     # googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
@@ -22,7 +22,6 @@ output:
 .wrapper {
   color: black;
   background-color: white;
-  border: 1px solid black;
 }
 .coordinates {
   color: #333;

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -1,20 +1,19 @@
 ---
-author: "Tareef Kawaf"
+logo: "https://www.rstudio.com/wp-content/uploads/2016/09/RStudio-Logo-Blue-Gray-250.png"
+name: "Tareef Kawaf"
 title: "President of RStudio, Inc."
+phone: "+1 844-448-1212"
+email: "info@rstudio.com"
+url: www.rstudio.com
+address: |
+  @rstudio
+person: 
+  - name: Yihui Xie
+    title: Responsible of `r grep('(?<!shut)down$', rownames(installed.packages()), value=T, perl=T)`
 output:
-  pagedown::business_card:
-    logo: "https://www.rstudio.com/wp-content/uploads/2016/09/RStudio-Logo-Blue-Gray-250.png"
+  pagedown::business_card: default
     # googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
 ---
-
-+1 844-448-1212
-
-info@rstudio.com
-
-www.rstudio.com
-
-@rstudio
-
 
 
 <!-- if you prefer black text on white background, set eval=TRUE on the chunk below -->

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -29,6 +29,7 @@ output:
 .wrapper {
   color: black;
   background-color: white;
+  border: 1px dotted black;
 }
 .coordinates {
   color: #333;

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -8,11 +8,11 @@ address: |
 person: 
   - name: Tareef Kawaf
     title: President of RStudio, Inc.
-    repeat: 6
+    repeat: 12
   - name: Yihui Xie
     title: Responsible for `r grep('(?<!shut)down$', unique(rownames(installed.packages())), value=T, perl=T)`
-    repeat: 6
-  - Jane Doe
+    email: xie@yihui.name
+    repeat: 12
 output:
   pagedown::business_card: 
     cols: 4

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -1,25 +1,25 @@
 ---
-logo: "https://www.rstudio.com/wp-content/uploads/2016/09/RStudio-Logo-Blue-Gray-250.png"
 phone: "+1 844-448-1212"
 email: "info@rstudio.com"
 url: www.rstudio.com
 address: |
   @rstudio
+logo: "https://www.rstudio.com/wp-content/uploads/2016/09/RStudio-Logo-Blue-Gray-250.png"
 person: 
   - name: Tareef Kawaf
     title: President of RStudio, Inc.
     repeat: 12
   - name: Yihui Xie
-    title: Responsible for `r grep('(?<!shut)down$', unique(rownames(installed.packages())), value=T, perl=T)`
+    title: Responsible for `r head(grep('(?<!shut)down$', unique(.packages(T)), value=T, perl=T), 2)`
     email: xie@yihui.name
+    url: https://yihui.name
     repeat: 12
-output:
-  pagedown::business_card: 
-    cols: 4
-    rows: 3
-    paperwidth: 8.5in
-    paperheight: 11in
-    # googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
+# googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
+paperwidth: 8.5in
+paperheight: 11in
+cols: 4
+rows: 3
+output: pagedown::business_card
 ---
 
 <!-- if you prefer you can create cards in markdown instead of YAML declaration -->

--- a/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/business-card/skeleton/skeleton.Rmd
@@ -9,7 +9,7 @@ address: |
   @rstudio
 person: 
   - name: Yihui Xie
-    title: Responsible of `r grep('(?<!shut)down$', rownames(installed.packages()), value=T, perl=T)`
+    title: Responsible for `r grep('(?<!shut)down$', rownames(installed.packages()), value=T, perl=T)`
 output:
   pagedown::business_card: default
     # googlefonts: "Righteous" # feel free to try other fonts at https://fonts.google.com
@@ -22,6 +22,7 @@ output:
 .wrapper {
   color: black;
   background-color: white;
+  border: 1px solid black;
 }
 .coordinates {
   color: #333;

--- a/man/business_card.Rd
+++ b/man/business_card.Rd
@@ -4,8 +4,8 @@
 \alias{business_card}
 \title{Create business cards}
 \usage{
-business_card(logo = NULL, width = "2in", height = "3in", paperwidth = "8.5in", 
-    paperheight = "11in", cols = 4, rows = 3, googlefonts = "Montserrat", 
+business_card(logo = NULL, width = "2in", height = "3in", paperwidth = "2in", 
+    paperheight = "3in", cols = 1, rows = 1, googlefonts = "Montserrat", 
     mainfont = googlefonts)
 }
 \arguments{

--- a/man/business_card.Rd
+++ b/man/business_card.Rd
@@ -15,5 +15,5 @@ This output format is based on an example in the Github repo
 \url{https://pagedown.rbind.io/business-card/} for an example.
 }
 \examples{
-pagedown::business_card(googlefonts = "Lato")
+pagedown::business_card()
 }

--- a/man/business_card.Rd
+++ b/man/business_card.Rd
@@ -5,7 +5,8 @@
 \title{Create business cards}
 \usage{
 business_card(logo = NULL, width = "2in", height = "3in", paperwidth = "8.5in", 
-    paperheight = "11in", googlefonts = "Montserrat", mainfont = googlefonts)
+    paperheight = "11in", cols = 4, rows = 3, googlefonts = "Montserrat", 
+    mainfont = googlefonts)
 }
 \arguments{
 \item{logo}{Path or URL to a logo.}
@@ -13,6 +14,8 @@ business_card(logo = NULL, width = "2in", height = "3in", paperwidth = "8.5in",
 \item{width, height}{Width and height of the card.}
 
 \item{paperwidth, paperheight}{Width and height of the paper.}
+
+\item{cols, rows}{Number of columns and rows per page.}
 
 \item{googlefonts}{Names of Google fonts to be loaded on the card page.}
 

--- a/man/business_card.Rd
+++ b/man/business_card.Rd
@@ -4,13 +4,15 @@
 \alias{business_card}
 \title{Create business cards}
 \usage{
-business_card(logo = NULL, width = "2in", height = "3in", googlefonts = "Montserrat", 
-    mainfont = googlefonts)
+business_card(logo = NULL, width = "2in", height = "3in", paperwidth = "8.5in", 
+    paperheight = "11in", googlefonts = "Montserrat", mainfont = googlefonts)
 }
 \arguments{
 \item{logo}{Path or URL to a logo.}
 
 \item{width, height}{Width and height of the card.}
+
+\item{paperwidth, paperheight}{Width and height of the paper.}
 
 \item{googlefonts}{Names of Google fonts to be loaded on the card page.}
 

--- a/man/business_card.Rd
+++ b/man/business_card.Rd
@@ -4,13 +4,10 @@
 \alias{business_card}
 \title{Create business cards}
 \usage{
-business_card(logo = NULL, width = "2in", height = "3in", paperwidth = "2in", 
-    paperheight = "3in", cols = 1, rows = 1, googlefonts = "Montserrat", 
-    mainfont = googlefonts)
+business_card(width = "2in", height = "3in", paperwidth = "2in", paperheight = "3in", 
+    cols = 1, rows = 1, googlefonts = "Montserrat", mainfont = googlefonts)
 }
 \arguments{
-\item{logo}{Path or URL to a logo.}
-
 \item{width, height}{Width and height of the card.}
 
 \item{paperwidth, paperheight}{Width and height of the paper.}

--- a/man/business_card.Rd
+++ b/man/business_card.Rd
@@ -4,19 +4,7 @@
 \alias{business_card}
 \title{Create business cards}
 \usage{
-business_card(width = "2in", height = "3in", paperwidth = "2in", paperheight = "3in", 
-    cols = 1, rows = 1, googlefonts = "Montserrat", mainfont = googlefonts)
-}
-\arguments{
-\item{width, height}{Width and height of the card.}
-
-\item{paperwidth, paperheight}{Width and height of the paper.}
-
-\item{cols, rows}{Number of columns and rows per page.}
-
-\item{googlefonts}{Names of Google fonts to be loaded on the card page.}
-
-\item{mainfont}{Names of fonts to be used for the body text of the card.}
+business_card()
 }
 \value{
 An R Markdown output format.


### PR DESCRIPTION
Here's a proposal to resolve #55 

In this PR, I did **major evolutions** of the business card template: 

- new features: multiple cards in the same page; cards can be different and share common informations (address, website...)
- cards can be created using YAML variables or markdown
- except the `author` field that is renamed `name` and the `logo` variable moved to pandoc template, the default behavior of `business_card()` is left unchanged (ie one card on one single page)
- I've documented in `inst/examples/index.Rmd` the new features
- technically, I used HTML `template` and shadow DOM for sharing common informations among cards
