### PR TITLE
get status code from Network.responseReceived Event.

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -219,7 +219,7 @@ print_pdf = function(ps, ws, url, output, wait, verbose, token) {
       # Command #6 received - Test if the html document uses the paged.js polyfill
       # if not, call the binding when fonts are ready
         if (!isTRUE(msg$result$result$value))
-          ws$send('{"id":6,"method":"Runtime.evaluate","params":{"expression":"document.fonts.ready.then(() => {pagedownListener(\'\');})"}}')
+          ws$send('{"id":7,"method":"Runtime.evaluate","params":{"expression":"document.fonts.ready.then(() => {pagedownListener(\'\');})"}}')
       },
       # Command #7 received - No callback
       NULL, {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -229,10 +229,10 @@ print_pdf = function(ps, ws, url, output, wait, verbose, token) {
     )
     if (!is.null(method)) {
       if (method == "Network.responseReceived") {
-        status_code = as.numeric(msg$params$response$status)
-        if (status_code >= 300) {
-          stop(sprintf("Erreur on http status code: %s returned", status_code))
-        }
+        status = as.numeric(msg$params$response$status)
+        if (status >= 400) token$error = sprintf(
+          "Failed to open %s (HTTP status code: %s)", url, status
+        )
       }
       if (method == "Page.loadEventFired") {
         ws$send('{"id":6,"method":"Runtime.evaluate","params":{"expression":"!!window.PagedPolyfill"}}')

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -195,13 +195,13 @@ print_pdf = function(ps, ws, url, output, wait, verbose, token) {
   })
 
   ws$onMessage(function(event) {
-    if (!is.null(token$error)) return()
+    if (!is.null(token$error)) return(ws$close())
     if (verbose) message('Message received from headless Chrome: ', event$data)
     msg = jsonlite::fromJSON(event$data)
     id = msg$id
     method = msg$method
 
-    if (!is.null(token$error <- msg$error)) return()
+    if (!is.null(token$error <- msg$error)) return(ws$close())
 
     if (!is.null(id)) switch(
       id,

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -200,7 +200,7 @@ print_pdf = function(ps, ws, url, output, wait, verbose, token) {
     id = msg$id
     method = msg$method
 
-    if (!is.null(token$error <- msg$error)) return()
+    if (!is.null(token$error) || !is.null(token$error <- msg$error)) return()
 
     if (!is.null(id)) switch(
       id,

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -231,7 +231,7 @@ print_pdf = function(ps, ws, url, output, wait, verbose, token) {
       if (method == "Network.responseReceived") {
         status = as.numeric(msg$params$response$status)
         if (status >= 400) token$error = sprintf(
-          "Failed to open %s (HTTP status code: %s)", url, status
+          "Failed to open %s (HTTP status code: %s)", msg$params$response$url, status
         )
       }
       if (method == "Page.loadEventFired") {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -195,12 +195,13 @@ print_pdf = function(ps, ws, url, output, wait, verbose, token) {
   })
 
   ws$onMessage(function(event) {
+    if (!is.null(token$error)) return()
     if (verbose) message('Message received from headless Chrome: ', event$data)
     msg = jsonlite::fromJSON(event$data)
     id = msg$id
     method = msg$method
 
-    if (!is.null(token$error) || !is.null(token$error <- msg$error)) return()
+    if (!is.null(token$error <- msg$error)) return()
 
     if (!is.null(id)) switch(
       id,


### PR DESCRIPTION
This tries to deal with #66 

The `Network.responseReceived` event from Chrome Devtools Protocol contains the response content, including information from status code. (there is a lots of others informations too!)

This is to show that it works, and stop if status code is above 300.

```r
> chrome_bin <- Sys.getenv("HEADLESS_CHROME")
> pagedown::chrome_print('https://pagedown.rbind.io/html-letter2', verbose = T, browser = chrome_bin)
Message received from headless Chrome: {"method":"Runtime.executionContextCreated","params":{"context":{"id":1,"origin":"://","name":"","auxData":{"isDefault":true,"frameId":"2E48A3FFEB1A7B14E5AD10AF42BFCB98"}}}}
Message received from headless Chrome: {"id":1,"result":{}}
Message received from headless Chrome: {"id":2,"result":{}}
Message received from headless Chrome: {"id":3,"result":{}}
Message received from headless Chrome: {"id":4,"result":{}}
Message received from headless Chrome: {"method":"Network.requestWillBeSent","params":{"requestId":"1FFB09FCDBD3E9AED1D04B436E76BDF3","loaderId":"1FFB09FCDBD3E9AED1D04B436E76BDF3","documentURL":"https://pagedown.rbind.io/html-letter2","request":{"url":"https://pagedown.rbind.io/html-letter2","method":"GET","headers":{"Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/70.0.3508.0 Safari/537.36"},"mixedContentType":"none","initialPriority":"VeryHigh","referrerPolicy":"no-referrer-when-downgrade"},"timestamp":86419.385241,"wallTime":1549650254.187218,"initiator":{"type":"other"},"type":"Document","frameId":"2E48A3FFEB1A7B14E5AD10AF42BFCB98","hasUserGesture":false}}
Message received from headless Chrome: {"method":"Network.responseReceived","params":{"requestId":"1FFB09FCDBD3E9AED1D04B436E76BDF3","loaderId":"1FFB09FCDBD3E9AED1D04B436E76BDF3","timestamp":86419.867971,"type":"Document","response":{"url":"https://pagedown.rbind.io/html-letter2","status":404,"statusText":"","headers":{"status":"404","date":"Fri, 08 Feb 2019 18:24:14 GMT","content-type":"text/html; charset=utf-8","set-cookie":"__cfduid=df880244ab0641b5881d5b2b93e19a0b01549650254; expires=Sat, 08-Feb-20 18:24:14 GMT; path=/; domain=.rbind.io; HttpOnly","cache-control":"public, max-age=0, must-revalidate","x-nf-srv-version":"45aaffea081549dd03a2dfff644cc25cf522edbd","age":"1123","x-nf-request-id":"bb470534-927c-4138-b38a-b2bdc1d77520-25476550","expect-ct":"max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"","server":"cloudflare","cf-ray":"4a6021c9de7db79b-CDG","content-encoding":"gzip"},"mimeType":"text/html","requestHeaders":{":method":"GET",":authority":"pagedown.rbind.io",":scheme":"https",":path":"/html-letter2","upgrade-insecure-requests":"1","user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/70.0.3508.0 Safari/537.36","accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8","accept-encoding":"gzip, deflate"},"connectionReused":false,"connectionId":10,"remoteIPAddress":"104.31.77.168","remotePort":443,"fromDiskCache":false,"fromServiceWorker":false,"encodedDataLength":383,"timing":{"requestTime":86419.385595,"proxyStart":26.377,"proxyEnd":31.445,"dnsStart":32.261,"dnsEnd":106.31,"connectStart":106.31,"connectEnd":175.317,"sslStart":119.678,"sslEnd":175.286,"workerStart":-1,"workerReady":-1,"sendStart":175.802,"sendEnd":176.099,"pushStart":0,"pushEnd":0,"receiveHeadersEnd":481.714},"protocol":"h2","securityState":"secure","securityDetails":{"protocol":"TLS 1.2","keyExchange":"ECDHE_ECDSA","keyExchangeGroup":"X25519","cipher":"AES_128_GCM","certificateId":0,"subjectName":"sni108475.cloudflaressl.com","sanList":["sni108475.cloudflaressl.com","*.ambercom.co","*.amstournament.com","*.archidamosakridas.tk","*.bookperformance.cf","*.bwinfor.ml","*.cos.name","*.cosx.org","*.daftarhargahp.biz","*.dentistboyntonbeachfl.net","*.drakbardds.com","*.epimitheaszygomalas.tk","*.evinosgiannaris.tk","*.fingerflossing.com","*.handpieceexpress.net","*.hargaku.me","*.hargaku.tech","*.homeopathie-bewustwording.nu","*.howardluksmd.com","*.janeluvsdick.com","*.jerryhan.net","*.k-hdcamreview.ml","*.lazy.sh","*.leonidasleivadas.tk","*.leotychidaslaimos.tk","*.lixy.im","*.maillsender.net","*.meropastomaraioi.tk","*.milfmuetter.com","*.ninjamac.com","*.ninjamac.tech","*.nowteaseme.org","*.orthoinfoguide.com","*.palmvalleywomenscare.com","*.playvid.me","*.podetrazer.com.br","*.rbind.io","*.rbind.org","*.sedgewickeye.com","*.sexyfreereliable.online","*.smashpdfbook.tk","*.taubefamilydental.com","*.yihui.name","*.zelienoplesmiles.com","ambercom.co","amstournament.com","archidamosakridas.tk","bookperformance.cf","bwinfor.ml","cos.name","cosx.org","daftarhargahp.biz","dentistboyntonbeachfl.net","drakbardds.com","epimitheaszygomalas.tk","evinosgiannaris.tk","fingerflossing.com","handpieceexpress.net","hargaku.me","hargaku.tech","homeopathie-bewustwording.nu","howardluksmd.com","janeluvsdick.com","jerryhan.net","k-hdcamreview.ml","lazy.sh","leonidasleivadas.tk","leotychidaslaimos.tk","lixy.im","maillsender.net","meropastomaraioi.tk","milfmuetter.com","ninjamac.com","ninjamac.tech","nowteaseme.org","orthoinfoguide.com","palmvalleywomenscare.com","playvid.me","podetrazer.com.br","rbind.io","rbind.org","sedgewickeye.com","sexyfreereliable.online","smashpdfbook.tk","taubefamilydental.com","yihui.name","zelienoplesmiles.com"],"issuer":"COMODO ECC Domain Validation Secure Server CA 2","validFrom":1548633600,"validTo":1565135999,"signedCertificateTimestampList":[],"certificateTransparencyCompliance":"unknown"}},"frameId":"2E48A3FFEB1A7B14E5AD10AF42BFCB98"}}
Error in execCallbacks(timeoutSecs) : 
  Evaluation error: Evaluation error: Erreur on http status code: 404 returned..
Call `rlang::last_error()` to see a backtrace
```

This surely need adjustment to give informative message and stop nicely.

Does it cover the case of not accessible page for you ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/pagedown/67)
<!-- Reviewable:end -->
