### PR TITLE
Fix #68: serve the local HTML file through servr::httd() and print it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),
@@ -25,4 +25,4 @@ SystemRequirements: Pandoc (>= 2.2.3)
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
-Remotes: rstudio/websocket
+Remotes: rstudio/websocket, yihui/servr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Description: Use the paged media properties in CSS and the JavaScript
   pages. Each page can have its page size, page numbers, margin boxes, and
   running headers, etc. Applications of this package include books, letters,
   reports, papers, business cards, resumes, and posters.
-Imports: rmarkdown (>= 1.11), bookdown (>= 0.8), htmltools, jsonlite, later, processx, websocket, servr (>= 0.12), xfun
+Imports: rmarkdown (>= 1.11), bookdown (>= 0.8), htmltools, jsonlite, later,
+  processx, websocket, servr (>= 0.12), httpuv, xfun
 Suggests: testit, xaringan
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -50,7 +50,7 @@ chrome_print = function(
     )
     sv = servr::httd(
       dirname(url), daemon = TRUE, browser = FALSE, verbose = FALSE,
-      initpath = httpuv::encodeURIComponent(basename(url))
+      port = random_port(), initpath = httpuv::encodeURIComponent(basename(url))
     )
     on.exit(sv$stop_server(), add = TRUE)
     url = sv$url
@@ -74,7 +74,7 @@ chrome_print = function(
     '--headless', '--no-first-run', '--no-default-browser-check'
   ))
 
-  debug_port = servr::random_port()
+  debug_port = random_port()
   ps = processx::process$new(browser, c(
     paste0('--remote-debugging-port=', debug_port),
     paste0('--user-data-dir=', work_dir), extra_args

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -48,12 +48,12 @@ chrome_print = function(
     if (!is_html(url)) stop(
       "The file '", url, "' should have the '.html' or '.htm' extension."
     )
-    sv = servr::httd(
+    svr = servr::httd(
       dirname(url), daemon = TRUE, browser = FALSE, verbose = FALSE,
       port = random_port(), initpath = httpuv::encodeURIComponent(basename(url))
     )
-    on.exit(sv$stop_server(), add = TRUE)
-    url = sv$url
+    on.exit(svr$stop_server(), add = TRUE)
+    url = svr$url
   } else url = input  # the input is not a local file; assume it is just a URL
 
   # remove hash/query parameters in url

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,3 +27,7 @@ merge_list = function(x, y) {
   x[names(y)] = y
   x
 }
+
+# don't prefer the port 4321 (otherwise we may see the meaningless error message
+# "createTcpServer: address already in use" too often)
+random_port = function() servr::random_port(NULL)

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -2,15 +2,17 @@
 % Please edit documentation in R/chrome.R
 \name{chrome_print}
 \alias{chrome_print}
-\title{Print a web page to PDF using the headless Chrome (experimental)}
+\title{Print a web page to PDF using the headless Chrome}
 \usage{
-chrome_print(url, output = xfun::with_ext(url, "pdf"), wait = 2, 
+chrome_print(input, output = xfun::with_ext(input, "pdf"), wait = 2, 
     browser = "google-chrome", options = list(printBackground = TRUE, 
         preferCSSPageSize = TRUE), work_dir = tempfile(), timeout = 30, 
     extra_args = c("--disable-gpu"), verbose = FALSE)
 }
 \arguments{
-\item{url}{A URL or local file path to a web page.}
+\item{input}{A URL or local file path to an HTML page, or a path to a local
+file that can be rendered to HTML via \code{rmarkdown::\link{render}()}
+(e.g., an R Markdown document or an R script).}
 
 \item{output}{The (PDF) output filename. For a local web page
 \file{foo/bar.html}, the default PDF output is \file{foo/bar.pdf}; for a
@@ -47,9 +49,8 @@ Chrome.}
 Path of the output file (invisibly).
 }
 \description{
-This is a wrapper function to execute the command \command{chrome --headless
---print-to-pdf url}. Google Chrome (or Chromium on Linux) must be installed
-prior to using this function.
+Print an HTML page to PDF through the Chrome DevTools Protocol. Google Chrome
+(or Chromium on Linux) must be installed prior to using this function.
 }
 \references{
 \url{https://developers.google.com/web/updates/2017/04/headless-chrome}


### PR DESCRIPTION
If the input file is not HTML, call `rmarkdown::render()` to render it to HTML first.