### PR TITLE
No websocket package but use httpuv server 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R: c(
   person("Adam", "Hyde", role = "ctb", comment = "paged.js in resources/js/"),
   person("Min-Zhong", "Lu", role = "ctb", comment = "resume.css in resources/css/"),
   person("Zulko", role = "ctb", comment = "poster-relaxed.css in resources/css/"),
+  person("Christophe", "Dervieux", role = c("ctb"), comment = c(ORCID = "0000-0003-4474-2498")),
   person()
   )
 Description: Use the paged media properties in CSS and the JavaScript

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Use the paged media properties in CSS and the JavaScript
   running headers, etc. Applications of this package include books, letters,
   reports, papers, business cards, resumes, and posters.
 Imports: rmarkdown (>= 1.11), bookdown (>= 0.8), htmltools, jsonlite, later,
-  processx, websocket, servr (>= 0.12), httpuv, xfun
+  processx, servr (>= 0.12), httpuv, xfun
 Suggests: testit, xaringan
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown
@@ -26,4 +26,4 @@ SystemRequirements: Pandoc (>= 2.2.3)
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
-Remotes: rstudio/websocket, yihui/servr
+Remotes: yihui/servr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,11 +5,11 @@ Version: 0.1.8
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),
+  person("Christophe", "Dervieux", role = c("ctb"), comment = c(ORCID = "0000-0003-4474-2498")),
   person(family = "RStudio, Inc.", role = "cph"),
   person("Adam", "Hyde", role = "ctb", comment = "paged.js in resources/js/"),
   person("Min-Zhong", "Lu", role = "ctb", comment = "resume.css in resources/css/"),
   person("Zulko", role = "ctb", comment = "poster-relaxed.css in resources/css/"),
-  person("Christophe", "Dervieux", role = c("ctb"), comment = c(ORCID = "0000-0003-4474-2498")),
   person()
   )
 Description: Use the paged media properties in CSS and the JavaScript

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -290,37 +290,9 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
 ws_server = function(cdp_ws_url, browser) {
   app = list(
     call = function(req) {
-      list(
-        status = 200L,
-        headers = list(
-          'Content-Type' = 'text/html'
-        ),
-        body = paste0(collapse = "\r\n",
-                      c("<!DOCTYPE html>",
-                        "<html>",
-                        "<head>",
-                        "</head>",
-                        "<body>",
-                        "</body>",
-                        '<script type="text/javascript">',
-                          # Create the connection to the httpuv server:
-                          'var httpuv = new WebSocket("ws://" + window.location.host);',
-                          # Create the connection to headless Chrome:
-                          sprintf('var chromeConnection = new WebSocket("%s");', cdp_ws_url),
-                          # Configure the connection with headless Chrome:
-                          "chromeConnection.onmessage = function(event) {",
-                            # send chrome message to R
-                            "   httpuv.send(event.data)",
-                            "   var data = JSON.parse(event.data);",
-                          "};",
-                          "httpuv.onmessage = function(event) {",
-                            "  chromeConnection.send(event.data);",
-                          "};",
-                        "</script>",
-                        "</html>"
-                      )
-        )
-      )
+      list(status = 200L, headers = list('Content-Type' = 'text/html'), body = sprintf(
+        xfun::file_string(pkg_resource('html', 'ws-server.html')), cdp_ws_url
+      ))
     },
     # Configure the server-side websocket connection
     onWSOpen = function(ws) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -94,7 +94,7 @@ chrome_print = function(
   if (!is_remote_protocol_ok(debug_port, ps)) {
     stop('A more recent version of Chrome is required. ')
   }
-  httpuv_app = start_ws_server(get_entrypoint(debug_port), browser = browser)
+  httpuv_app = ws_server(get_entrypoint(debug_port), browser = browser)
   on.exit({
     if (httpuv_app$ps$is_alive()) httpuv_app$ps$kill()
     httpuv::stopServer(httpuv_app$server)
@@ -287,7 +287,7 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
 }
 
 
-start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), browser) {
+ws_server = function(cdp_ws_url, browser) {
   app = list(
     call = function(req) {
       list(

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -98,7 +98,7 @@ chrome_print = function(
   # there to the above Chrome process (messages come back in the same way); this
   # is mainly to unblock newer CRAN releases of pagedown because the websocket
   # package is not on CRAN (yet)
-  app = ws_server(get_entrypoint(debug_port), browser = browser)
+  app = ws_server(debug_port, browser = browser)
   on.exit({
     if (app$ps$is_alive()) app$ps$kill()
     httpuv::stopServer(app$server)
@@ -291,7 +291,8 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
 }
 
 
-ws_server = function(ws_url, browser) {
+ws_server = function(port, browser) {
+  ws_url = get_entrypoint(port)
   app = list(
     call = function(req) {
       list(status = 200L, headers = list('Content-Type' = 'text/html'), body = sprintf(

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -304,7 +304,7 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), browser) {
                         "</body>",
                         '<script type="text/javascript">',
                           # Create the connection to the httpuv server:
-                          'var httpuv = new WebSocket("ws://"+location.host);',
+                          'var httpuv = new WebSocket("ws://" + window.location.host);',
                           # Create the connection to headless Chrome:
                           sprintf('var chromeConnection = new WebSocket("%s");', cdp_ws_url),
                           # Configure the connection with headless Chrome:

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -288,7 +288,7 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
 
 
 start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), browser) {
-  app <- list(
+  app = list(
     call = function(req) {
       list(
         status = 200L,
@@ -328,10 +328,10 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), browser) {
       ws_con <<- ws
     }
   )
-  ws_con <- NULL
+  ws_con = NULL
   httpuv_port = random_port()
-  server <- httpuv::startServer("0.0.0.0", httpuv_port, app)
-  workdir <-  tempfile()
+  server = httpuv::startServer("0.0.0.0", httpuv_port, app)
+  workdir =  tempfile()
   debug_port = random_port()
   ps = processx::process$new(
     command = browser,

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -293,6 +293,7 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
 
 ws_server = function(port, browser) {
   ws_url = get_entrypoint(port)
+  ws_con = NULL
   app = list(
     call = function(req) {
       list(status = 200L, headers = list('Content-Type' = 'text/html'), body = sprintf(
@@ -305,7 +306,6 @@ ws_server = function(port, browser) {
       ws_con <<- ws
     }
   )
-  ws_con = NULL
   httpuv_port = random_port()
   server = httpuv::startServer("0.0.0.0", httpuv_port, app)
   workdir =  tempfile()

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -343,7 +343,7 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), browser) {
       '--headless',
       '--no-first-run',
       '--no-default-browser-check',
-      paste0("http://localhost:", httpuv_port)
+      paste0("http://127.0.0.1:", httpuv_port)
   ))
   while (is.null(ws_con)) {
     if (!ps$is_alive()) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -304,11 +304,6 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), verbose = T
   )
   app <- list(
     call = function(req) {
-      wsUrl = paste(sep='',
-                    '"',
-                    "ws://",
-                    ifelse(is.null(req$HTTP_HOST), req$SERVER_NAME, req$HTTP_HOST),
-                    '"')
       list(
         status = 200L,
         headers = list(
@@ -326,6 +321,7 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), verbose = T
                           if (verbose) write_log,
                           # Create the connection to the httpuv server:
                           sprintf("var httpuv = new WebSocket(%s);", wsUrl),
+                          'var httpuv = new WebSocket("ws://"+location.host);',
                           # Create the connection to headless Chrome:
                           sprintf('var chromeConnection = new WebSocket("%s");', cdp_ws_url),
                           # Configure the connection with headless Chrome:

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -344,15 +344,11 @@ start_ws_server <- function(url, headless_address = get_entrypoint(debug_port), 
     },
     # Configure the server-side websocket connection
     onWSOpen = function(ws) {
+      # return websocket object when created
       ws_con <<- ws
-      # In this POC, the only message received by the httpuv server is the pdf
-      ws$onMessage(function(binary, message) {
-        # ws$send('{mgs: "Received from server")')
-        message("Message Received")
-      })
     }
   )
   ws_con <- NULL
   server <- httpuv::startServer("0.0.0.0", 9454, app)
-  return(ws_con)
+  list(server = server, ws = ws_con)
 }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -343,7 +343,7 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), browser) {
       '--headless',
       '--no-first-run',
       '--no-default-browser-check',
-      paste0("http://localhost", httpuv_port)
+      paste0("http://localhost:", httpuv_port)
   ))
   while (is.null(ws_con)) {
     if (!ps$is_alive()) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -354,10 +354,14 @@ start_ws_server <- function(cdp_ws_url = get_entrypoint(debug_port), verbose = T
   )
   ws_con <- NULL
   server <- httpuv::startServer("0.0.0.0", 9454, app)
+  workdir <-  tempfile()
+  message(workdir)
+  debug_port = random_port()
   ps = processx::process$new(
     command = browser,
     args = c(
-      paste0('--user-data-dir=', tempfile()),
+      paste0('--user-data-dir=', workdir),
+      paste0('--remote-debugging-port=', debug_port),
       '--disable-gpu', "--no-sandbox",
       '--headless',
       '--no-first-run',

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -106,7 +106,7 @@ chrome_print = function(
   t0 = Sys.time(); token = new.env(parent = emptyenv())
   print_page(ws, url, output2, wait, verbose, token, format, options)
   while (!isTRUE(token$done)) {
-    if (!app$ps$is_alive()) stop("httpuv chrome crashed")
+    if (!app$ps$is_alive()) stop('Chrome launched via httpuv crashed')
     if (!is.null(e <- token$error)) stop('Failed to generate output. Reason: ', e)
     if (as.numeric(difftime(Sys.time(), t0, units = 'secs')) > timeout) stop(
       'Failed to generate output in ', timeout, ' seconds (timeout).'
@@ -303,26 +303,24 @@ ws_server = function(port, browser) {
     }
   )
   httpuv_port = random_port()
-  server = httpuv::startServer("0.0.0.0", httpuv_port, app)
-  workdir =  tempfile()
-  debug_port = random_port()
+  server = httpuv::startServer('127.0.0.1', httpuv_port, app)
   ps = processx::process$new(
     command = browser,
     args = c(
-      paste0('--user-data-dir=', workdir),
-      paste0('--remote-debugging-port=', debug_port),
+      paste0('--user-data-dir=', workdir <- tempfile()),
+      paste0('--remote-debugging-port=', random_port()),
       '--disable-gpu',
       if (xfun::is_windows()) '--no-sandbox',
       '--headless',
       '--no-first-run',
       '--no-default-browser-check',
-      paste0("http://127.0.0.1:", httpuv_port)
+      paste0('http://127.0.0.1:', httpuv_port)
   ))
   while (is.null(ws_con)) {
     if (!ps$is_alive()) {
       # something went wrong with chrome while creating the websocket.
       httpuv::stopServer(server)
-      stop("httpuv chrome crashed before creating websocket")
+      stop('Chrome launched via httpuv crashed before creating websocket')
     }
     httpuv::service()
   }

--- a/inst/resources/html/ws-server.html
+++ b/inst/resources/html/ws-server.html
@@ -7,8 +7,7 @@
 var httpuv = new WebSocket("ws://" + window.location.host);
 var chromeConnection = new WebSocket("%s");
 chromeConnection.onmessage = function(event) {
-   httpuv.send(event.data)
-   var data = JSON.parse(event.data);
+  httpuv.send(event.data)
 };
 httpuv.onmessage = function(event) {
   chromeConnection.send(event.data);

--- a/inst/resources/html/ws-server.html
+++ b/inst/resources/html/ws-server.html
@@ -3,7 +3,7 @@
 <head>
 </head>
 <body>
-<script type="text/javascript">
+<script>
 var httpuv = new WebSocket("ws://" + window.location.host);
 var chromeConnection = new WebSocket("%s");
 chromeConnection.onmessage = function(event) {

--- a/inst/resources/html/ws-server.html
+++ b/inst/resources/html/ws-server.html
@@ -3,7 +3,6 @@
 <head>
 </head>
 <body>
-</body>
 <script type="text/javascript">
 var httpuv = new WebSocket("ws://" + window.location.host);
 var chromeConnection = new WebSocket("%s");
@@ -15,4 +14,5 @@ httpuv.onmessage = function(event) {
   chromeConnection.send(event.data);
 };
 </script>
+</body>
 </html>

--- a/inst/resources/html/ws-server.html
+++ b/inst/resources/html/ws-server.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+</body>
+<script type="text/javascript">
+var httpuv = new WebSocket("ws://" + window.location.host);
+var chromeConnection = new WebSocket("%s");
+chromeConnection.onmessage = function(event) {
+   httpuv.send(event.data)
+   var data = JSON.parse(event.data);
+};
+httpuv.onmessage = function(event) {
+  chromeConnection.send(event.data);
+};
+</script>
+</html>


### PR DESCRIPTION
This is the work of the weekend. 🎉 

Pagedown can now work without websocket github 📦 

This is possible by using a httpuv server with websocket actinc as a tunnel between R and chrome. 
This allows to not change the logic of the code but just how the websocket object is created. 

One of the trick is that for httpuv server to run it requires a web browser, another chrome browser is opened, headless with remote protocol. 

I let you test it on other computer than mine (a windows).

If this works ok for you, it would mean than `chrome_print` can find its way to CRAN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/pagedown/74)
<!-- Reviewable:end -->
