### PR TITLE
Wait HTMLWidgets and MathJax before printing

### DIFF
--- a/inst/resources/js/chrome_print.js
+++ b/inst/resources/js/chrome_print.js
@@ -1,0 +1,44 @@
+(() => {
+  let HTMLWidgetsReady = new Promise((resolve) => {
+    window.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        if (window.HTMLWidgets) {
+          HTMLWidgets.addPostRenderHandler(resolve);
+        } else {
+          resolve();
+        }
+      },
+      {capture: true, once: true}
+    );
+  });
+
+  let MathJaxReady = new Promise((resolve) => {
+    window.addEventListener(
+      'load',
+      () => {
+        if (window.MathJax) {
+          if (window.MathJax.Hub) {
+           window.MathJax.Hub.Register.StartupHook('Begin', () => {
+              window.MathJax.Hub.Queue(resolve);
+            });
+          } else {
+            let previousAuthorInit = window.MathJax.AuthorInit || function () {};
+            window.MathJax.AuthorInit = function() {
+              previousAuthorInit();
+              MathJax.Hub.Register.StartupHook('Begin', () => {
+                MathJax.Hub.Queue(resolve);
+              });
+            };
+          }
+        }
+        else {
+          resolve();
+        }
+      },
+      {capture: true, once: true}
+    );
+  });
+
+  window.pagedownReady = Promise.all([MathJaxReady, HTMLWidgetsReady, document.fonts.ready]);
+})();


### PR DESCRIPTION
The goal of this PR is to wait HTMLWidgets and MathJax for non Paged.js documents as explained here https://github.com/rstudio/pagedown/pull/64#pullrequestreview-200886912

I did several tests with several Rmd output formats, it seems to work well.

I wonder whether there are other JS libraries used in the R Markdown ecosystem that the `chrome_print()` function should wait.
