### PR TITLE
Allow chrome_print() to be used in a container

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -323,6 +323,7 @@ ws_server = function(port, browser, extra_args) {
     args = unique(c(
       paste0('--user-data-dir=', workdir <- tempfile()),
       paste0('--remote-debugging-port=', random_port()),
+      '--disable-gpu',
       if (xfun::is_windows()) '--no-sandbox',
       '--headless',
       '--no-first-run',

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -34,7 +34,6 @@
 #' @param extra_args Extra command-line arguments to be passed to Chrome.
 #' @param verbose Whether to show verbose websocket connection to headless
 #'   Chrome.
-#' @param containerized Whether the function is run in a (Docker) container.
 #' @references
 #' \url{https://developers.google.com/web/updates/2017/04/headless-chrome}
 #' @return Path of the output file (invisibly).
@@ -42,8 +41,7 @@
 chrome_print = function(
   input, output = xfun::with_ext(input, format), wait = 2, browser = 'google-chrome',
   format = c('pdf', 'png', 'jpeg'), options = list(),
-  work_dir = tempfile(), timeout = 30, extra_args = c('--disable-gpu'), verbose = FALSE,
-  containerized = FALSE
+  work_dir = tempfile(), timeout = 30, extra_args = c('--disable-gpu'), verbose = FALSE
 ) {
   if (missing(browser)) browser = find_chrome() else {
     if (!file.exists(browser)) browser = Sys.which(browser)
@@ -83,7 +81,7 @@ chrome_print = function(
   # for windows, use the --no-sandbox option
   extra_args = unique(c(
     extra_args, proxy_args(),
-    if (xfun::is_windows() | isTRUE(containerized)) '--no-sandbox',
+    if (xfun::is_windows()) '--no-sandbox',
     '--headless', '--no-first-run', '--no-default-browser-check', '--hide-scrollbars'
   ))
 
@@ -104,7 +102,7 @@ chrome_print = function(
   # there to the above Chrome process (messages come back in the same way); this
   # is mainly to unblock newer CRAN releases of pagedown because the websocket
   # package is not on CRAN (yet)
-  app = ws_server(debug_port, browser, containerized)
+  app = ws_server(debug_port, browser, extra_args)
   on.exit(app$cleanup(), add = TRUE)
 
   ws = app$ws
@@ -304,7 +302,7 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
 }
 
 
-ws_server = function(port, browser, containerized) {
+ws_server = function(port, browser, extra_args) {
   ws_url = get_entrypoint(port)
   ws_con = NULL
   app = list(
@@ -322,16 +320,17 @@ ws_server = function(port, browser, containerized) {
   server = httpuv::startServer('127.0.0.1', httpuv_port, app)
   ps = processx::process$new(
     command = browser,
-    args = c(
+    args = unique(c(
       paste0('--user-data-dir=', workdir <- tempfile()),
       paste0('--remote-debugging-port=', random_port()),
-      '--disable-gpu',
-      if (xfun::is_windows() | isTRUE(containerized)) '--no-sandbox',
+      if (xfun::is_windows()) '--no-sandbox',
       '--headless',
       '--no-first-run',
       '--no-default-browser-check',
-      paste0('http://127.0.0.1:', httpuv_port)
-  ))
+      paste0('http://127.0.0.1:', httpuv_port),
+      extra_args
+    ))
+  )
   while (is.null(ws_con)) {
     if (!ps$is_alive()) {
       # something went wrong with chrome while creating the websocket.

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -80,8 +80,7 @@ chrome_print = function(
 
   # for windows, use the --no-sandbox option
   extra_args = unique(c(
-    extra_args, proxy_args(),
-    if (xfun::is_windows()) '--no-sandbox',
+    extra_args, proxy_args(), if (xfun::is_windows()) '--no-sandbox',
     '--headless', '--no-first-run', '--no-default-browser-check', '--hide-scrollbars'
   ))
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -325,7 +325,7 @@ ws_server = function(port, browser) {
     args = c(
       paste0('--user-data-dir=', workdir <- tempfile()),
       paste0('--remote-debugging-port=', random_port()),
-      '--disable-gpu',
+      '--disable-gpu', '--no-sandbox',
       if (xfun::is_windows()) '--no-sandbox',
       '--headless',
       '--no-first-run',

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -31,13 +31,10 @@
 #'   home directory.
 #' @param timeout The number of seconds before canceling the document
 #'   generation. Use a larger value if the document takes longer to build.
-#' @param extra_args Extra command-line arguments to be passed to Chrome. Note
-#'   that when using this function in a (Docker) container, you should add the
-#'   \code{--no-sandbox} option, e.g., \code{extra_args = c('--disable-gpu',
-#'   '--no-sandbox')}.
+#' @param extra_args Extra command-line arguments to be passed to Chrome.
 #' @param verbose Whether to show verbose websocket connection to headless
 #'   Chrome.
-#' @param containerized Whether the function is run in a container.
+#' @param containerized Whether the function is run in a (Docker) container.
 #' @references
 #' \url{https://developers.google.com/web/updates/2017/04/headless-chrome}
 #' @return Path of the output file (invisibly).

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -7,7 +7,7 @@
 chrome_print(input, output = xfun::with_ext(input, format), wait = 2, 
     browser = "google-chrome", format = c("pdf", "png", "jpeg"), options = list(), 
     work_dir = tempfile(), timeout = 30, extra_args = c("--disable-gpu"), 
-    verbose = FALSE)
+    verbose = FALSE, containerized = FALSE)
 }
 \arguments{
 \item{input}{A URL or local file path to an HTML page, or a path to a local
@@ -53,6 +53,8 @@ that when using this function in a (Docker) container, you should add the
 
 \item{verbose}{Whether to show verbose websocket connection to headless
 Chrome.}
+
+\item{containerized}{Whether the function is run in a container.}
 }
 \value{
 Path of the output file (invisibly).

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -46,15 +46,12 @@ home directory.}
 \item{timeout}{The number of seconds before canceling the document
 generation. Use a larger value if the document takes longer to build.}
 
-\item{extra_args}{Extra command-line arguments to be passed to Chrome. Note
-that when using this function in a (Docker) container, you should add the
-\code{--no-sandbox} option, e.g., \code{extra_args = c('--disable-gpu',
-'--no-sandbox')}.}
+\item{extra_args}{Extra command-line arguments to be passed to Chrome.}
 
 \item{verbose}{Whether to show verbose websocket connection to headless
 Chrome.}
 
-\item{containerized}{Whether the function is run in a container.}
+\item{containerized}{Whether the function is run in a (Docker) container.}
 }
 \value{
 Path of the output file (invisibly).

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -4,10 +4,10 @@
 \alias{chrome_print}
 \title{Print a web page to PDF or capture a screenshot using the headless Chrome}
 \usage{
-chrome_print(input, output = xfun::with_ext(input, format), wait = 2, 
-    browser = "google-chrome", format = c("pdf", "png", "jpeg"), options = list(), 
-    work_dir = tempfile(), timeout = 30, extra_args = c("--disable-gpu"), 
-    verbose = FALSE, containerized = FALSE)
+chrome_print(input, output = xfun::with_ext(input, format), wait = 2,
+  browser = "google-chrome", format = c("pdf", "png", "jpeg"),
+  options = list(), work_dir = tempfile(), timeout = 30,
+  extra_args = c("--disable-gpu"), verbose = FALSE)
 }
 \arguments{
 \item{input}{A URL or local file path to an HTML page, or a path to a local
@@ -50,8 +50,6 @@ generation. Use a larger value if the document takes longer to build.}
 
 \item{verbose}{Whether to show verbose websocket connection to headless
 Chrome.}
-
-\item{containerized}{Whether the function is run in a (Docker) container.}
 }
 \value{
 Path of the output file (invisibly).


### PR DESCRIPTION
This is a small but I hope useful PR.

Because of the middleman chrome browser, the command `chrome_print(..., extra_args = c('--disable-gpu', '--no-sandbox'))` fails: the middleman chrome also needs the `--no-sandbox` option.
This PR is a proposal to add a `containerized` argument to the `chrome_print()` function.

I succeeded to generate a PDF in a container with `pagedown::chrome_print(..., containerized = TRUE)`.
You can find an example [here](https://rlesur.gitlab.io/chrome_print/index.pdf) (this is the default xaringan template).

@Bakaniko you can find the `.gitlab-ci.yml` I used [here](https://gitlab.com/RLesur/chrome_print/blob/master/.gitlab-ci.yml).

I used the Puppeteer in docker configuration: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker

The main commands of the container configuration are the following:
```yml
- apt-get update
- apt-get -yq install wget apt-transport-https ca-certificates gnupg --no-install-recommends
- apt-get -yq install libgconf-2-4
- wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
- sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
- apt-get update
- apt-get -yq install google-chrome-unstable fontconfig fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-symbola fonts-noto ttf-freefont --no-install-recommends
```