### PR TITLE
Synchronize connections inside the tunnel

### DIFF
--- a/inst/resources/html/ws-server.html
+++ b/inst/resources/html/ws-server.html
@@ -4,13 +4,18 @@
 </head>
 <body>
 <script>
-var httpuv = new WebSocket("ws://" + window.location.host);
-var chromeConnection = new WebSocket("%s");
-chromeConnection.onmessage = function(event) {
-  httpuv.send(event.data)
-};
-httpuv.onmessage = function(event) {
-  chromeConnection.send(event.data);
+var httpuv, chromeConnection = new WebSocket("%s");
+chromeConnection.onopen = function(event) {
+
+  httpuv = new WebSocket("ws://" + window.location.host);
+
+  this.onmessage = function(event) {
+    httpuv.send(event.data)
+  };
+
+  httpuv.onmessage = function(event) {
+    chromeConnection.send(event.data);
+  };
 };
 </script>
 </body>


### PR DESCRIPTION
I think I found why I got some unexpected fails with Travis (I also got sometimes similar fails on Windows).

In the tunnel, we create 2 websocket connections: `chromeConnection` (between the middleman and headless Chrome) and `httpuv` (between the middleman and the httpuv server).
The `ws_server()` function returns when the `httpuv` connection is opened. 
However, with the current implementation, we cannot be sure that the `chromeConnection` is opened when `ws_server()` returns.

Sometimes, the `chromeConnection` takes more time to be opened: the `ws_server()` returns and the `print_page()` function sends a message. Then, the tunnel try to send back the message to headless Chrome **but** the connection is not established. So, the tunnel silently crashes.

With this PR, we create the connection between the httpuv server and the middleman after the connection with headless Chrome is opened.

This solved my fails on Windows. It seems to work well on Travis.
