### PR TITLE
Screenshot capturing enhancements

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -287,9 +287,13 @@ print_page = function(
         '{"id":11,"method":"DOM.querySelector","params":{"nodeId":%i,"selector":"%s"}}',
         msg$result$root$nodeId,
         selector
-      )),
+      )), {
       # Command 11 received -> callback: command #12 DOM.getBoxModel
-      ws$send(sprintf('{"id":12,"method":"DOM.getBoxModel","params":{"nodeId":%i}}', msg$result$nodeId)), {
+        if (msg$result$nodeId == 0)
+          token$error <- 'No element in the HTML page corresponds to the `selector` value.'
+        else
+          ws$send(sprintf('{"id":12,"method":"DOM.getBoxModel","params":{"nodeId":%i}}', msg$result$nodeId))
+      }, {
       # Command 12 received -> callback: command #13 Page.captureScreenshot
         opts = as.list(options)
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -110,6 +110,9 @@ chrome_print = function(
 
   ws = app$ws
 
+  if ((format == 'pdf') & !all(c(missing(selector), missing(box_model), missing(scale))))
+    warning('For "pdf" format, arguments `selector`, `box_model` and `scale` are ignored.', call. = FALSE)
+
   box_model = match.arg(box_model)
 
   t0 = Sys.time(); token = new.env(parent = emptyenv())

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -307,6 +307,10 @@ print_page = function(
 
         clip = c(origin, dims, list(scale = scale))
         opts = merge_list(list(clip = clip), opts)
+        message(
+          'Screenshot captured with the following value for the `options` parameter:\n',
+          paste0(deparse(opts), collapse = '\n ')
+        )
         opts$format = format
 
         ws$send(jsonlite::toJSON(list(

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -289,10 +289,11 @@ print_page = function(
         selector
       )), {
       # Command 11 received -> callback: command #12 DOM.getBoxModel
-        if (msg$result$nodeId == 0)
+        if (msg$result$nodeId == 0) {
           token$error <- 'No element in the HTML page corresponds to the `selector` value.'
-        else
+        } else {
           ws$send(sprintf('{"id":12,"method":"DOM.getBoxModel","params":{"nodeId":%i}}', msg$result$nodeId))
+        }
       }, {
       # Command 12 received -> callback: command #13 Page.captureScreenshot
         opts = as.list(options)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -28,6 +28,7 @@
 #'   \code{preferCSSPageSize} (\code{TRUE}) in this function.
 #' @param selector A CSS selector used when capturing a screenshot.
 #' @param box_model The CSS box model used when capturing a screenshot.
+#' @param scale The scale factor used for screenshot.
 #' @param work_dir Name of headless Chrome working directory. If the default
 #'   temporary directory doesn't work, you may try to use a subdirectory of your
 #'   home directory.
@@ -43,7 +44,7 @@
 chrome_print = function(
   input, output = xfun::with_ext(input, format), wait = 2, browser = 'google-chrome',
   format = c('pdf', 'png', 'jpeg'), options = list(),
-  selector = 'body', box_model = c('border', 'content', 'margin', 'padding'),
+  selector = 'body', box_model = c('border', 'content', 'margin', 'padding'), scale = 1,
   work_dir = tempfile(), timeout = 30, extra_args = c('--disable-gpu'), verbose = FALSE
 ) {
   if (missing(browser)) browser = find_chrome() else {
@@ -112,7 +113,7 @@ chrome_print = function(
   box_model = match.arg(box_model)
 
   t0 = Sys.time(); token = new.env(parent = emptyenv())
-  print_page(ws, url, output2, wait, verbose, token, format, options, selector, box_model)
+  print_page(ws, url, output2, wait, verbose, token, format, options, selector, box_model, scale)
   while (!isTRUE(token$done)) {
     if (!app$ps$is_alive()) stop('Chrome launched via httpuv crashed')
     if (!is.null(e <- token$error)) stop('Failed to generate output. Reason: ', e)
@@ -238,7 +239,8 @@ get_entrypoint = function(debug_port) {
 }
 
 print_page = function(
-  ws, url, output, wait, verbose, token, format, options = list(), selector, box_model
+  ws, url, output, wait, verbose, token, format,
+  options = list(), selector, box_model, scale
 ) {
 
   ws$onMessage(function(binary, text) {
@@ -296,7 +298,7 @@ print_page = function(
         dims = as.list(coords[5:6] - coords[1:2])
         names(dims) = c('width', 'height')
 
-        clip = c(origin, dims, list(scale = 1))
+        clip = c(origin, dims, list(scale = scale))
         opts = merge_list(list(clip = clip), opts)
         opts$format = format
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -26,6 +26,7 @@
 #'    for options for screenshots. Note that for PDF output, we have changed the
 #'   defaults of \code{printBackground} (\code{TRUE}) and
 #'   \code{preferCSSPageSize} (\code{TRUE}) in this function.
+#' @param selector A CSS selector used when capturing a screenshot.
 #' @param work_dir Name of headless Chrome working directory. If the default
 #'   temporary directory doesn't work, you may try to use a subdirectory of your
 #'   home directory.
@@ -40,7 +41,7 @@
 #' @export
 chrome_print = function(
   input, output = xfun::with_ext(input, format), wait = 2, browser = 'google-chrome',
-  format = c('pdf', 'png', 'jpeg'), options = list(),
+  format = c('pdf', 'png', 'jpeg'), options = list(), selector = 'body',
   work_dir = tempfile(), timeout = 30, extra_args = c('--disable-gpu'), verbose = FALSE
 ) {
   if (missing(browser)) browser = find_chrome() else {
@@ -107,7 +108,7 @@ chrome_print = function(
   ws = app$ws
 
   t0 = Sys.time(); token = new.env(parent = emptyenv())
-  print_page(ws, url, output2, wait, verbose, token, format, options)
+  print_page(ws, url, output2, wait, verbose, token, format, options, selector)
   while (!isTRUE(token$done)) {
     if (!app$ps$is_alive()) stop('Chrome launched via httpuv crashed')
     if (!is.null(e <- token$error)) stop('Failed to generate output. Reason: ', e)
@@ -183,6 +184,7 @@ is_remote_protocol_ok = function(debug_port, max_attempts = 15) {
   }
 
   required_commands = list(
+    DOM = c('enable', 'getBoxModel', 'getDocument', 'querySelector'),
     Network = c('enable'),
     Page = c('addScriptToEvaluateOnNewDocument',
              'captureScreenshot',
@@ -231,7 +233,7 @@ get_entrypoint = function(debug_port) {
   page
 }
 
-print_page = function(ws, url, output, wait, verbose, token, format, options = list()) {
+print_page = function(ws, url, output, wait, verbose, token, format, options = list(), selector) {
 
   ws$onMessage(function(binary, text) {
     if (!is.null(token$error)) return(ws$close())
@@ -266,8 +268,29 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
           ws$send('{"id":8,"method":"Runtime.evaluate","params":{"expression":"pagedownReady.then(() => {pagedownListener(\'\');})"}}')
       },
       # Command #8 received - No callback
-      NULL, {
-      # Command #9 received (printToPDF or captureScreenshot) -> callback: save to file & close Chrome
+      NULL,
+      # Command #9 received -> callback: command #10 DOM.getDocument
+      ws$send('{"id":10,"method":"DOM.getDocument"}'),
+      # Command #10 received -> callback: command #11 DOM.querySelector
+      ws$send(sprintf(
+        '{"id":11,"method":"DOM.querySelector","params":{"nodeId":%i,"selector":"%s"}}',
+        msg$result$root$nodeId,
+        selector
+      )),
+      # Command 11 received -> callback: command #12 DOM.getBoxModel
+      ws$send(sprintf('{"id":12,"method":"DOM.getBoxModel","params":{"nodeId":%i}}', msg$result$nodeId)), {
+      # Command 12 received -> callback: command #13 Page.captureScreenshot
+        opts = as.list(options)
+        origin = as.list(msg$result$model$padding[1:2]) # content, padding, border and margin are available in msg$rsult$model
+        names(origin) = c('x', 'y')
+        clip = c(origin, msg$result$model[c('width', 'height')], list(scale = 1))
+        opts = merge_list(list(clip = clip), opts)
+        opts$format = format
+        ws$send(jsonlite::toJSON(list(
+          id = 13, params = opts, method = 'Page.captureScreenshot'
+        ), auto_unbox = TRUE, null = 'null'))
+      }, {
+      # Command #13 received (printToPDF or captureScreenshot) -> callback: save to file & close Chrome
         writeBin(jsonlite::base64_dec(msg$result$data), output)
         token$done = TRUE
       }
@@ -285,13 +308,14 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
       if (method == "Runtime.bindingCalled") {
         Sys.sleep(wait)
         opts = as.list(options)
-        if (format == 'pdf')
+        if (format == 'pdf') {
           opts = merge_list(list(printBackground = TRUE, preferCSSPageSize = TRUE), opts)
-        if (format == 'jpeg') opts$format = 'jpeg'
-        ws$send(jsonlite::toJSON(list(
-          id = 9, params = if (length(opts)) opts,
-          method = if (format == 'pdf') 'Page.printToPDF' else 'Page.captureScreenshot'
-        ), auto_unbox = TRUE, null = 'null'))
+          ws$send(jsonlite::toJSON(list(
+            id = 13, params = opts, method = 'Page.printToPDF'
+          ), auto_unbox = TRUE, null = 'null'))
+        } else {
+          ws$send('{"id":9,"method":"DOM.enable"}')
+        }
       }
     }
   })

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -110,7 +110,7 @@ chrome_print = function(
 
   ws = app$ws
 
-  if ((format == 'pdf') & !all(c(missing(selector), missing(box_model), missing(scale))))
+  if ((format == 'pdf') && !all(c(missing(selector), missing(box_model), missing(scale))))
     warning('For "pdf" format, arguments `selector`, `box_model` and `scale` are ignored.', call. = FALSE)
 
   box_model = match.arg(box_model)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -283,7 +283,9 @@ print_page = function(ws, url, output, wait, verbose, token, format, options = l
         opts = as.list(options)
         origin = as.list(msg$result$model$padding[1:2]) # content, padding, border and margin are available in msg$rsult$model
         names(origin) = c('x', 'y')
-        clip = c(origin, msg$result$model[c('width', 'height')], list(scale = 1))
+        dims = as.list(msg$result$model$padding[5:6] - msg$result$model$padding[1:2])
+        names(dims) = c('width', 'height')
+        clip = c(origin, dims, list(scale = 1))
         opts = merge_list(list(clip = clip), opts)
         opts$format = format
         ws$send(jsonlite::toJSON(list(

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -4,10 +4,10 @@
 \alias{chrome_print}
 \title{Print a web page to PDF or capture a screenshot using the headless Chrome}
 \usage{
-chrome_print(input, output = xfun::with_ext(input, format), wait = 2,
-  browser = "google-chrome", format = c("pdf", "png", "jpeg"),
-  options = list(), work_dir = tempfile(), timeout = 30,
-  extra_args = c("--disable-gpu"), verbose = FALSE)
+chrome_print(input, output = xfun::with_ext(input, format), wait = 2, 
+    browser = "google-chrome", format = c("pdf", "png", "jpeg"), 
+    options = list(), selector = "body", work_dir = tempfile(), timeout = 30, 
+    extra_args = c("--disable-gpu"), verbose = FALSE)
 }
 \arguments{
 \item{input}{A URL or local file path to an HTML page, or a path to a local
@@ -38,6 +38,8 @@ explicitly provided.}
  for options for screenshots. Note that for PDF output, we have changed the
 defaults of \code{printBackground} (\code{TRUE}) and
 \code{preferCSSPageSize} (\code{TRUE}) in this function.}
+
+\item{selector}{A CSS selector used when capturing a screenshot.}
 
 \item{work_dir}{Name of headless Chrome working directory. If the default
 temporary directory doesn't work, you may try to use a subdirectory of your

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -5,9 +5,10 @@
 \title{Print a web page to PDF or capture a screenshot using the headless Chrome}
 \usage{
 chrome_print(input, output = xfun::with_ext(input, format), wait = 2, 
-    browser = "google-chrome", format = c("pdf", "png", "jpeg"), 
-    options = list(), selector = "body", work_dir = tempfile(), timeout = 30, 
-    extra_args = c("--disable-gpu"), verbose = FALSE)
+    browser = "google-chrome", format = c("pdf", "png", "jpeg"), options = list(), 
+    selector = "body", box_model = c("border", "content", "margin", "padding"), 
+    work_dir = tempfile(), timeout = 30, extra_args = c("--disable-gpu"), 
+    verbose = FALSE)
 }
 \arguments{
 \item{input}{A URL or local file path to an HTML page, or a path to a local
@@ -40,6 +41,8 @@ defaults of \code{printBackground} (\code{TRUE}) and
 \code{preferCSSPageSize} (\code{TRUE}) in this function.}
 
 \item{selector}{A CSS selector used when capturing a screenshot.}
+
+\item{box_model}{The CSS box model used when capturing a screenshot.}
 
 \item{work_dir}{Name of headless Chrome working directory. If the default
 temporary directory doesn't work, you may try to use a subdirectory of your

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -7,7 +7,7 @@
 chrome_print(input, output = xfun::with_ext(input, format), wait = 2, 
     browser = "google-chrome", format = c("pdf", "png", "jpeg"), options = list(), 
     selector = "body", box_model = c("border", "content", "margin", "padding"), 
-    work_dir = tempfile(), timeout = 30, extra_args = c("--disable-gpu"), 
+    scale = 1, work_dir = tempfile(), timeout = 30, extra_args = c("--disable-gpu"), 
     verbose = FALSE)
 }
 \arguments{
@@ -43,6 +43,8 @@ defaults of \code{printBackground} (\code{TRUE}) and
 \item{selector}{A CSS selector used when capturing a screenshot.}
 
 \item{box_model}{The CSS box model used when capturing a screenshot.}
+
+\item{scale}{The scale factor used for screenshot.}
 
 \item{work_dir}{Name of headless Chrome working directory. If the default
 temporary directory doesn't work, you may try to use a subdirectory of your


### PR DESCRIPTION
Following the discussion in #73 I took some time to improve the screenshot functionnality of `chrome_print()`. With this PR:

## The full page is captured by default
```r
pagedown::chrome_print('https://pagedown.rbind.io/poster-relaxed', format = 'png')
```
![poster-relaxed](https://user-images.githubusercontent.com/19177171/53675992-fdac4100-3c9c-11e9-9d41-ca50ef4006ca.png)

## A single element can be captured using a CSS selector
```r
pagedown::chrome_print('https://pagedown.rbind.io/poster-relaxed', selector = '#authors', format = 'png')
``` 
![poster-relaxed](https://user-images.githubusercontent.com/19177171/53676017-63003200-3c9d-11e9-9d96-6bdc2b60ce43.png)

## Other parameters
With the `box_model` argument, the user can select the CSS box model used for capturing the screenshot.
The `scale` factor can be used to increase/decrease the size.
