### PR TITLE
Use chrome_print in a Shiny app (#91)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Use the paged media properties in CSS and the JavaScript
   running headers, etc. Applications of this package include books, letters,
   reports, papers, business cards, resumes, and posters.
 Imports: rmarkdown (>= 1.11), bookdown (>= 0.8), htmltools, jsonlite, later,
-  processx, servr (>= 0.13), httpuv, xfun
+  processx, servr (>= 0.13), httpuv, xfun, promises, shiny
 Suggests: testit, xaringan
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ Description: Use the paged media properties in CSS and the JavaScript
   running headers, etc. Applications of this package include books, letters,
   reports, papers, business cards, resumes, and posters.
 Imports: rmarkdown (>= 1.11), bookdown (>= 0.8), htmltools, jsonlite, later,
-  processx, servr (>= 0.13), httpuv, xfun, promises, shiny
-Suggests: testit, xaringan
+  processx, servr (>= 0.13), httpuv, xfun
+Suggests: promises, testit, xaringan
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown
 BugReports: https://github.com/rstudio/pagedown/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN pagedown VERSION 0.3
 
+## NEW FEATURES
+
+- Added an `async` argument to `chrome_print()`. When `async = TRUE`, `chrome_print()` returns a `promises::promise` object. This allows `chrome_print()` to be used inside a Shiny App (thanks, @ColinFay, #91).
+
 ## MAJOR CHANGES
 
 - Paged.js is upgraded from version 0.1.28 to 0.1.32: Paged.js CSS variables are now prefixed with `pagedjs-`. For instance, `--width` is replaced by `--pagedjs-width`. Users' stylesheets that use Paged.js CSS variables need to be updated. Bleeds and crop marks are now supported. Several bugs are fixed.

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -40,7 +40,8 @@
 #'   screenshots); \code{2} (or \code{TRUE}) means all messages, including those
 #'   from the Chrome processes and WebSocket connections.
 #' @param async Execute \code{chrome_print()} asynchronously? If \code{TRUE},
-#'   \code{chrome_print()} returns a \code{\link[promises]{promise}} value.
+#'   \code{chrome_print()} returns a \code{\link[promises]{promise}} value (the
+#'   \pkg{promises} package has to be installed in this case).
 #' @references
 #' \url{https://developers.google.com/web/updates/2017/04/headless-chrome}
 #' @return Path of the output file (invisibly). If \code{async} is \code{TRUE}, this

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -125,7 +125,7 @@ chrome_print = function(
   if (is_shiny) {
     pr <- promises::promise(function(resolve, reject) res_fun <<- resolve)
     on.exit()
-    promises::then(pr, ~ app$cleanup())
+    promises::finally(pr, ~ app$cleanup())
   }
 
   t0 = Sys.time(); token = new.env(parent = emptyenv())

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -121,10 +121,10 @@ chrome_print = function(
 
   box_model = match.arg(box_model)
 
-  pr <- NULL
-  res_fun <- NULL
+  pr = NULL
+  res_fun = NULL
   if (async <- async && xfun::loadable('promises')) {
-    pr <- promises::promise(function(resolve, reject) res_fun <<- resolve)
+    pr = promises::promise(function(resolve, reject) res_fun <<- resolve)
     on.exit()
     promises::finally(pr, ~ app$cleanup())
   }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -277,9 +277,9 @@ print_page = function(
 
   ws$onMessage(function(binary, text) {
     if (!is.null(token$error)) {
-      res = ws$close()
+      ws$close()
       reject(token$error)
-      return(res)
+      return()
     }
     if (verbose >= 2) message('Message received from headless Chrome: ', text)
     msg = jsonlite::fromJSON(text)
@@ -287,9 +287,9 @@ print_page = function(
     method = msg$method
 
     if (!is.null(token$error <- msg$error$message)) {
-      res = ws$close()
+      ws$close()
       reject(token$error)
-      return(res)
+      return()
     }
 
     if (!is.null(id)) switch(

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -8,7 +8,7 @@ chrome_print(input, output = xfun::with_ext(input, format), wait = 2,
     browser = "google-chrome", format = c("pdf", "png", "jpeg"), options = list(), 
     selector = "body", box_model = c("border", "content", "margin", "padding"), 
     scale = 1, work_dir = tempfile(), timeout = 30, extra_args = c("--disable-gpu"), 
-    verbose = 0)
+    verbose = 0, async = FALSE)
 }
 \arguments{
 \item{input}{A URL or local file path to an HTML page, or a path to a local
@@ -59,10 +59,13 @@ generation. Use a larger value if the document takes longer to build.}
 to print out some auxiliary messages (e.g., parameters for capturing
 screenshots); \code{2} (or \code{TRUE}) means all messages, including those
 from the Chrome processes and WebSocket connections.}
+
+\item{async}{Execute \code{chrome_print()} asynchronously? If \code{TRUE},
+\code{chrome_print()} returns a \code{\link[promises]{promise}} value.}
 }
 \value{
-Path of the output file (invisibly). In a Shiny context, this value is
-  a \code{\link[promises]{promise}}.
+Path of the output file (invisibly). If \code{async} is \code{TRUE}, this
+  is a \code{\link[promises]{promise}} value.
 }
 \description{
 Print an HTML page to PDF or capture a PNG/JPEG screenshot through the Chrome

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -61,7 +61,8 @@ screenshots); \code{2} (or \code{TRUE}) means all messages, including those
 from the Chrome processes and WebSocket connections.}
 }
 \value{
-Path of the output file (invisibly).
+Path of the output file (invisibly). In a Shiny context, this value is
+  a \code{\link[promises]{promise}}.
 }
 \description{
 Print an HTML page to PDF or capture a PNG/JPEG screenshot through the Chrome

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -61,7 +61,8 @@ screenshots); \code{2} (or \code{TRUE}) means all messages, including those
 from the Chrome processes and WebSocket connections.}
 
 \item{async}{Execute \code{chrome_print()} asynchronously? If \code{TRUE},
-\code{chrome_print()} returns a \code{\link[promises]{promise}} value.}
+\code{chrome_print()} returns a \code{\link[promises]{promise}} value (the
+\pkg{promises} package has to be installed in this case).}
 }
 \value{
 Path of the output file (invisibly). If \code{async} is \code{TRUE}, this


### PR DESCRIPTION
I had a sudden idea tonight: I remembered that the profound nature of `chrome_print()` was asynchronous.
With #65, we have transformed this async function to a synchronous one using `later::run_now()`.
I also remembered this [blog post](https://blog.rstudio.com/2018/06/26/shiny-1-1-0/) that explains that promises can be used in a Shiny app.

So, here is a proposal to fix #91. I've tested this PR with the example provided by @ColinFay and it works well. The only caveat is that with @ColinFay's example, the screenshot is taken with the initial value (of bins).

I have to confess that I don't know Shiny and I have never used it (sorry, RStudio folks!). So, I don't know how to modify @ColinFay's example. I let Shiny users do this part.