### PR TITLE
Better style for code blocks with line numbers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),
   person("Christophe", "Dervieux", role = c("ctb"), comment = c(ORCID = "0000-0003-4474-2498")),
+  person("Atsushi", "Yasumoto", role = c("ctb"), comment = c(ORCID = "0000-0002-8335-495X")),
   person(family = "RStudio, Inc.", role = "cph"),
   person("Adam", "Hyde", role = "ctb", comment = "paged.js in resources/js/"),
   person("Min-Zhong", "Lu", role = "ctb", comment = "resume.css in resources/css/"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 
 - Paged.js is upgraded from version 0.1.28 to 0.1.32: Paged.js CSS variables are now prefixed with `pagedjs-`. For instance, `--width` is replaced by `--pagedjs-width`. Users' stylesheets that use Paged.js CSS variables need to be updated. Bleeds and crop marks are now supported. Several bugs are fixed.
 
+## MINOR CHANGES
+
+- The default stylesheet of `html_paged()` is updated to support the new argument `clean_highlight_tags` of `bookdown::html_document2()` introduced in **bookdown** 0.10 (thanks, @atusy, #100).
+
 ## BUG FIXES
 
 - browser is forced to redraw the document after Paged.js finished. This will fix wrong page references observed with Chrome and RStudio 1.2.xxxx (#35 and #46, thanks, @petermeissner).  

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -69,6 +69,10 @@ pre {
 pre[class] {
   background: #f9f9f9;
 }
+pre.numberSource a.sourceLine {
+  left: 0 !important;
+  text-indent: -5em
+}
 table {
   margin: auto;
   border-top: 1px solid #666;

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -81,6 +81,9 @@ pre.numberSource a.sourceLine {
   left: 0 !important;
   text-indent: -5em
 }
+pre.numberSource {
+  margin-left: 0 !important;
+}
 table {
   margin: auto;
   border-top: 1px solid #666;

--- a/inst/resources/css/default.css
+++ b/inst/resources/css/default.css
@@ -69,6 +69,14 @@ pre {
 pre[class] {
   background: #f9f9f9;
 }
+@media screen {
+  div.sourceCode {
+    overflow: visible !important;
+  }
+  a.sourceLine::before { 
+    text-decoration: unset !important; 
+  }
+}
 pre.numberSource a.sourceLine {
   left: 0 !important;
   text-indent: -5em


### PR DESCRIPTION
The latest `bookdown` package on GitHub enables `pagedown::html_paged` to put line numbers on code blocks. 

However, the result looks ugly like following.

![Screenshot from 2019-05-07 14-30-31](https://user-images.githubusercontent.com/30277794/57275299-0e33ca00-70d9-11e9-9c7f-2e586e5a1afb.png)

So I added a following lines to `default.css`.

``` css
pre.numberSource a.sourceLine {
  left: 0 !important;
  text-indent: -5em
}
```

The result looks nice.

![Screenshot from 2019-05-07 14-29-15](https://user-images.githubusercontent.com/30277794/57275303-10962400-70d9-11e9-9684-12975ba37728.png)


Although I don't like `left: 0 !important;`, `!important` is required because pandoc will add following lines after `default.css` to overide `left`.

``` css
pre.numberSource a.sourceLine
    { position: relative; left: -4em; }
```





# Reproducible example

````
---
output: 
  pagedown::html_paged: 
    highlight: pygments
    clean_highlight_tags: false
---


```{.numberLines}
Very very looooooooooooooooooooooooooong code.
```
````
