### PR TITLE
add google-chrome-stable to linux binary search

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -184,7 +184,7 @@ find_chrome = function() {
     unix = if (xfun::is_macos()) {
       '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
     } else {
-      for (i in c('google-chrome', 'chromium-browser', 'chromium')) {
+      for (i in c('google-chrome', 'chromium-browser', 'chromium', 'google-chrome-stable')) {
         if ((res <- Sys.which(i)) != '') break
       }
       if (res == '') stop('Cannot find Chromium or Google Chrome')


### PR DESCRIPTION
Fixes #104 

Addresses the name of the google-chrome binary in Arch Linux. A list of installation package names can be found here: https://wiki.archlinux.org/index.php/Chromium#Installation

This PR just adds `google-chrome-stable` to the candidate list because my machine was unable to find `google-chrome` when trying to run `chrome_print`