### PR TITLE
changes defaults for is_remote_protocol_ok

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -227,7 +227,7 @@ is_remote_protocol_ok = function(debug_port,
   # can be specify with option, for ex. for CI specificity. see #117
   max_attempts = getOption("pagedown.remote.maxattempts", 20L)
   sleep_time = getOption("pagedown.remote.sleeptime", 0.5)
-  if (verbose >= 1) message('Checking the remote connection in ', max_attempts, 'attempts.')
+  if (verbose >= 1) message('Checking the remote connection in ', max_attempts, ' attempts.')
   for (i in seq_len(max_attempts)) {
     remote_protocol = tryCatch(suppressWarnings(jsonlite::read_json(url)), error = function(e) NULL)
     if (!is.null(remote_protocol)) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -83,7 +83,7 @@ chrome_print = function(
   }
   on.exit(kill_chrome(), add = TRUE)
 
-  if (!is_remote_protocol_ok(debug_port))
+  if (!is_remote_protocol_ok(debug_port, verbose = verbose))
     stop('A more recent version of Chrome is required. ')
 
   ws = websocket::WebSocket$new(get_entrypoint(debug_port), autoConnect = FALSE)
@@ -221,16 +221,21 @@ no_proxy_urls = function() {
   unique(x)
 }
 
-is_remote_protocol_ok = function(debug_port, max_attempts = 100) {
+is_remote_protocol_ok = function(debug_port,
+                                 verbose = 0) {
   url = sprintf('http://127.0.0.1:%s/json/protocol', debug_port)
-  for (i in 1:max_attempts) {
+  # can be specify with option, for ex. for CI specificity. see #117
+  max_attempts = getOption("pagedown.remote.maxattempts", 20L)
+  sleep_time = getOption("pagedown.remote.sleeptime", 0.5)
+  if (verbose >= 1) message('Checking the remote connection in ', max_attempts, 'attempts.')
+  for (i in seq_len(max_attempts)) {
     remote_protocol = tryCatch(suppressWarnings(jsonlite::read_json(url)), error = function(e) NULL)
     if (!is.null(remote_protocol)) {
-      message('connected at attempt ', i)
+      if (verbose >= 1) message('Connected at attempt ', i)
       break
     }
-    if (i == max_attempts) stop('Cannot connect to headless Chrome after ', i, ' attempts')
-    Sys.sleep(0.5)
+    if (i == max_attempts) stop('Cannot connect to headless Chrome after ', max_attempts, ' attempts')
+    Sys.sleep(sleep_time)
   }
 
   required_commands = list(

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -221,13 +221,16 @@ no_proxy_urls = function() {
   unique(x)
 }
 
-is_remote_protocol_ok = function(debug_port, max_attempts = 15) {
+is_remote_protocol_ok = function(debug_port, max_attempts = 100) {
   url = sprintf('http://127.0.0.1:%s/json/protocol', debug_port)
   for (i in 1:max_attempts) {
     remote_protocol = tryCatch(suppressWarnings(jsonlite::read_json(url)), error = function(e) NULL)
-    if (!is.null(remote_protocol)) break
-    if (i == max_attempts) stop('Cannot connect to headless Chrome. ')
-    Sys.sleep(0.2)
+    if (!is.null(remote_protocol)) {
+      message('connected at attempt ', i)
+      break
+    }
+    if (i == max_attempts) stop('Cannot connect to headless Chrome after ', i, ' attempts')
+    Sys.sleep(0.5)
   }
 
   required_commands = list(


### PR DESCRIPTION
this should fix #117 

* default value increased to 20 tries and 0.5 sec sleep
* those can be configured with options (for advance use)
* messages added when verbose >= 1

I decided to not make those values arguments but only configurable by options. I think it is ok for this internal function. You'll tell me. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/pagedown/118)
<!-- Reviewable:end -->
