### PR TITLE
Support inerting front cover as an image

### DIFF
--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -111,6 +111,33 @@ $for(css)$
 <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
 $endfor$
 
+$if(front-cover)$
+<style type="text/css">
+@page :first {
+  --pagedjs-pagebox-width: 400mm;
+  @top-left-corner {content: none;}
+  @top-right-corner {content: none;}
+  @top-right {content: none;}
+  @bottom-right-corner {content: none;}
+}
+.front-cover {
+  break-after: page;
+}
+.cover-image {
+  height: var(--pagedjs-height);
+  width: var(--pagedjs-width);
+  object-fit: cover;
+  position: absolute;
+  top: calc(var(--pagedjs-margin-top)*-1);
+  left: calc(var(--pagedjs-margin-left)*-1);
+  z-index: 0;
+}
+.front-page {
+  counter-reset: page;
+}
+</style>
+$endif$
+
 $if(theme)$
 <style type = "text/css">
 .main-container {
@@ -143,6 +170,12 @@ $endif$
 $for(include-before)$
 $include-before$
 $endfor$
+
+$if(front-cover)$
+<div class="front-cover">
+  <img src="$front-cover$" class="cover-image" />
+</div>
+$endif$
 
 <div class="front-page">
 $if(title)$

--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -115,10 +115,6 @@ $if(front-cover)$
 <style type="text/css">
 @page :first {
   --pagedjs-pagebox-width: 400mm;
-  @top-left-corner {content: none;}
-  @top-right-corner {content: none;}
-  @top-right {content: none;}
-  @bottom-right-corner {content: none;}
 }
 .front-cover {
   break-after: page;
@@ -130,7 +126,6 @@ $if(front-cover)$
   position: absolute;
   top: calc(var(--pagedjs-margin-top)*-1);
   left: calc(var(--pagedjs-margin-left)*-1);
-  z-index: 0;
 }
 .front-page {
   counter-reset: page;

--- a/inst/resources/html/paged.html
+++ b/inst/resources/html/paged.html
@@ -114,7 +114,7 @@ $endfor$
 $if(front-cover)$
 <style type="text/css">
 @page :first {
-  --pagedjs-pagebox-width: 400mm;
+  --pagedjs-pagebox-width: 1000mm;
 }
 .front-cover {
   break-after: page;


### PR DESCRIPTION
By this PR, we can add cover image on the first page via the top-level yaml paramter `front-cover`

In a current implementation the image is resized to fit the page height and centered with aspect ratio remained.

Note that there is a hack to display image correctly:

```css
@page :first {
  --pagedjs-pagebox-width: 1000mm;
}
```

The width can be any if it is larger than page width.
Otherwise, right side of the image will be trimmed.

I also wanted to add `back-cover`, however, it was not possible as it seems impossible to specify CSS of the last page like `@page :last {}`.

## Example

![image](https://user-images.githubusercontent.com/30277794/63663630-1e91c100-c7fe-11e9-9c3a-b392aa8f4363.png)

### Source

#### Prepare cover image

```r
file.copy(system.file("img", "Rlogo.png", package="png"), "cover.png")
```

#### knit Rmd

````
---
title: "Title"
output: 
  pagedown::html_paged: 
    toc: true
    self_contained: false
front-cover: cover.png
---

# foo

````
