### PR TITLE
[chrome_print] Connect to the Browser websocket URL instead of the Page one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN pagedown VERSION 0.8
 
+## BUG FIXES
 
+- In `chrome_print()`, fixed some connection problems to headless Chrome: in some situations, the R session tries to connect to headless Chrome before a target is created. Now, `chrome_print()` controls the target creation by connecting to the `Browser` endpoint (thanks, @gershomtripp, #158).  
 
 # CHANGES IN pagedown VERSION 0.7
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -112,7 +112,7 @@ chrome_print = function(
 
   with_temp_loop_maybe({
 
-    ws = websocket::WebSocket$new(get_entrypoint(debug_port), autoConnect = FALSE)
+    ws = websocket::WebSocket$new(get_entrypoint(debug_port, verbose), autoConnect = FALSE)
     ws$onClose(kill_chrome)
     ws$onError(kill_chrome)
     close_ws = function() {
@@ -314,12 +314,14 @@ is_remote_protocol_ok = function(debug_port,
   )
 }
 
-get_entrypoint = function(debug_port) {
-  open_debuggers = jsonlite::read_json(
+get_entrypoint = function(debug_port, verbose) {
+  version_infos = jsonlite::read_json(
     sprintf('http://127.0.0.1:%s/json/version', debug_port), simplifyVector = TRUE
   )
-  browser = open_debuggers$webSocketDebuggerUrl
+  browser = version_infos$webSocketDebuggerUrl
   if (length(browser) == 0) stop("Cannot find 'Browser' websocket URL. Please retry.")
+  if (verbose >= 1)
+    message(version_infos$Browser, " found.")
   browser
 }
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -316,11 +316,11 @@ is_remote_protocol_ok = function(debug_port,
 
 get_entrypoint = function(debug_port) {
   open_debuggers = jsonlite::read_json(
-    sprintf('http://127.0.0.1:%s/json', debug_port), simplifyVector = TRUE
+    sprintf('http://127.0.0.1:%s/json/version', debug_port), simplifyVector = TRUE
   )
-  page = open_debuggers$webSocketDebuggerUrl[open_debuggers$type == 'page']
-  if (length(page) == 0) stop('Cannot connect R to Chrome. Please retry.')
-  page
+  browser = open_debuggers$webSocketDebuggerUrl
+  if (length(browser) == 0) stop("Cannot find 'Browser' websocket URL. Please retry.")
+  browser
 }
 
 print_page = function(

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -221,7 +221,7 @@ find_chrome = function() {
       res = head(res[file.exists(res)], 1)
       if (length(res) != 1) stop(
         'Cannot find Google Chrome automatically from the Windows Registry Hive. ',
-        "Please pass the full path of chrome.exe to the 'browser' argument",
+        "Please pass the full path of chrome.exe to the 'browser' argument ",
         "or to the environment variable 'PAGEDOWN_CHROME'."
       )
       res
@@ -262,14 +262,14 @@ is_remote_protocol_ok = function(debug_port,
   # can be specify with option, for ex. for CI specificity. see #117
   max_attempts = getOption("pagedown.remote.maxattempts", 20L)
   sleep_time = getOption("pagedown.remote.sleeptime", 0.5)
-  if (verbose >= 1) message('Checking the remote connection in ', max_attempts, ' attempts.')
+  if (verbose >= 1) message('Trying to find headless Chrome in ', max_attempts, ' attempts')
   for (i in seq_len(max_attempts)) {
     remote_protocol = tryCatch(suppressWarnings(jsonlite::read_json(url)), error = function(e) NULL)
     if (!is.null(remote_protocol)) {
-      if (verbose >= 1) message('Connected at attempt ', i)
+      if (verbose >= 1) message('Headless Chrome found at attempt ', i)
       break
     }
-    if (i == max_attempts) stop('Cannot connect to headless Chrome after ', max_attempts, ' attempts')
+    if (i == max_attempts) stop('Cannot find headless Chrome after ', max_attempts, ' attempts')
     Sys.sleep(sleep_time)
   }
 
@@ -322,7 +322,7 @@ get_entrypoint = function(debug_port, verbose) {
   browser = version_infos$webSocketDebuggerUrl
   if (length(browser) == 0) stop("Cannot find 'Browser' websocket URL. Please retry.")
   if (verbose >= 1)
-    message(version_infos$Browser, " found.")
+    message('Browser version: ', version_infos$Browser)
   browser
 }
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -282,7 +282,8 @@ is_remote_protocol_ok = function(debug_port,
              'navigate',
              'printToPDF'
     ),
-    Runtime = c('enable', 'addBinding', 'evaluate')
+    Runtime = c('enable', 'addBinding', 'evaluate'),
+    Target = c('attachToTarget', 'createTarget')
   )
 
   remote_domains = sapply(remote_protocol$domains, `[[`, 'domain')

--- a/tests/test-travis.R
+++ b/tests/test-travis.R
@@ -9,4 +9,7 @@ print_pdf = function(input) {
   )
 }
 
-if (!is.na(Sys.getenv('CI', NA))) testit::test_pkg('pagedown', 'test-travis')
+if (!is.na(Sys.getenv('CI', NA))) {
+  options(pagedown.remote.maxattempts = 100L)
+  testit::test_pkg('pagedown', 'test-travis')
+}


### PR DESCRIPTION
This is an attempt to fix #158. I'm unable to reproduce the bug declared in #158 but I think that controlling the target (i.e. tab or page) creation could resolve it. 

The strategy is the following:

- use the Browser websocket URL instead of the default Page websocket URL (I expect that the Browser URL is available before the Page one)
- send a command to create a new target
- attach this target: this creates a new session with a `sessionId`
- use this `sessionId` in all the commands

@gershomtripp Please, could you test this PR and tell me whether it solves the problem?  
You need first to install the PR version with:  
```r
remotes::install_github("rstudio/pagedown@cdp_session")
``` 