### PR TITLE
TOC bookmark to PDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - sourceline: 'ppa:cran/poppler'
     packages:
       - libpoppler-cpp-dev
+      - ghostscript
 
 before_install:
   - "curl https://xran.yihui.org/.gitconfig -o ~/.gitconfig"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
   person("Brent", "Thorne", role = "aut", comment = c(ORCID = "0000-0002-1099-3857")),
   person("Christophe", "Dervieux", role = c("ctb"), comment = c(ORCID = "0000-0003-4474-2498")),
   person("Atsushi", "Yasumoto", role = c("ctb"), comment = c(ORCID = "0000-0002-8335-495X")),
+  person("Xianying", "Tan", role = c("ctb"), comment = c(ORCID = "0000-0002-6072-3521")),
   person(family = "RStudio, PBC", role = "cph"),
   person("Adam", "Hyde", role = "ctb", comment = "paged.js in resources/js/"),
   person("Min-Zhong", "Lu", role = "ctb", comment = "resume.css in resources/css/"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.10.1
+Version: 0.10.2
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN pagedown VERSION 0.11
 
+## NEW FEATURES
+
+- `chrome_print()` now has a new argument `outline`, with which the user can generate the outline bookmarks for the PDF file. Note, this feature requires [Ghostscript](https://www.ghostscript.com) being installed and detected by `tools::find_gs_cmd()` (thanks, @shrektan, #174 #179).
 
 # CHANGES IN pagedown VERSION 0.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- `chrome_print()` now has a new argument `outline`, with which the user can generate the outline bookmarks for the PDF file. Note, this feature requires [Ghostscript](https://www.ghostscript.com) being installed and detected by `tools::find_gs_cmd()` (thanks, @shrektan, #174 #179).
+- `chrome_print()` now has a new argument `outline`, with which the user can generate the outline bookmarks for the PDF file. Note, this feature requires [Ghostscript](https://www.ghostscript.com) being installed and detected by `tools::find_gs_cmd()` (thanks, @shrektan, #174 and #179).
 
 # CHANGES IN pagedown VERSION 0.10
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -252,11 +252,9 @@ add_outline = function(pdf, toc_infos) {
     "See ?tools::find_gs_cmd for more details."
   )
   output = tempfile(fileext = '.pdf')
-  system2(
-    gs,
-    shQuote(c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', pdf, gs_file)),
-    stdout = FALSE, stderr = FALSE
-  )
+  args = c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', pdf, gs_file)
+  if (verbose < 2) args = c(args, '-q')
+  system2(gs, shQuote(args))
   file.rename(output, pdf)
   invisible(pdf)
 }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -200,7 +200,7 @@ chrome_print = function(
     if (is_rstudio_knit) message('\nOutput created: ', basename(output))
 
     # attach the TOC info
-    attr(output, "toc") = token$toc
+    attr(output, "toc_infos") = token$toc_infos
     invisible(output)
   })
 }
@@ -500,7 +500,8 @@ print_page = function(
       if (method == "Runtime.bindingCalled") {
         Sys.sleep(wait)
         opts = as.list(options)
-        payload = jsonlite::fromJSON(msg$params$payload)
+        payload = jsonlite::fromJSON(msg$params$payload, simplifyVector = FALSE)
+        token$toc_infos = payload$tocInfos
         if (verbose >= 1 && payload$pagedjs) {
           message("Rendered ", payload$pages, " pages in ", payload$elapsedtime, " milliseconds.")
         }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -250,11 +250,15 @@ add_outline = function(pdf, toc_infos) {
     "to the environment variable 'R_GSCMD'. ",
     "See ?tools::find_gs_cmd for more details."
   )
-  output = tempfile(fileext = '.pdf')
+  output = tempfile(fileext = '.pdf'); on.exit(unlink(output), add = TRUE)
   args = c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', pdf, gs_file)
   if (verbose < 2) args = c(args, '-q')
-  system2(find_gs(), shQuote(args))
-  file.rename(output, pdf)
+  gs_out = system2(find_gs(), shQuote(args))
+  if (gs_out == 0) {
+    file.rename(output, pdf)
+  } else {
+    warning('GhostScript fails to add the outlines', call. = FALSE)
+  }
   invisible(pdf)
 }
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -43,10 +43,11 @@
 #' @param async Execute \code{chrome_print()} asynchronously? If \code{TRUE},
 #'   \code{chrome_print()} returns a \code{\link[promises]{promise}} value (the
 #'   \pkg{promises} package has to be installed in this case).
-#' @param outline If not \code{FALSE}, \code{chrome_print()} will add the bookmark
-#'   to the generated pdf file, based on the TOC info. It's enabled by default,
-#'   as long as the Ghostscript executable can be detected by
-#'   \code{\link[tools]{find_gs_cmd}}.
+#' @param outline If not \code{FALSE}, \code{chrome_print()} will add the bookmarks
+#'   to the generated \code{pdf} file, based on the table of contents informations.
+#'   This feature is only available for output formats based on
+#'   \code{\link{html_paged}}. It is enabled by default, as long as the Ghostscript
+#'   executable can be detected by \code{\link[tools]{find_gs_cmd}}.
 #' @param encoding Not used. This argument is required by RStudio IDE.
 #' @references
 #' \url{https://developers.google.com/web/updates/2017/04/headless-chrome}

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -256,7 +256,7 @@ add_outline = function(input, toc_infos, verbose) {
     file.copy(input, input2)
   }
   args = c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', input2, gs_file)
-  if (verbose < 2) args = c(args, '-q')
+  if (verbose < 2) args = c('-q', args)
   gs_out = system2(find_gs(), shQuote(args))
   if (gs_out == 0) {
     file.rename(output, input)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -54,7 +54,7 @@ chrome_print = function(
   format = c('pdf', 'png', 'jpeg'), options = list(), selector = 'body',
   box_model = c('border', 'content', 'margin', 'padding'), scale = 1, work_dir = tempfile(),
   timeout = 30, extra_args = c('--disable-gpu'), verbose = 0, async = FALSE,
-  toc = TRUE, encoding
+  outline = TRUE, encoding
 ) {
   is_rstudio_knit =
     !interactive() && !is.na(Sys.getenv('RSTUDIO', NA)) &&
@@ -201,7 +201,7 @@ chrome_print = function(
     if (is_rstudio_knit) message('\nOutput created: ', basename(output))
 
     # attach the TOC info to the pdf file
-    if (toc) add_toc(output, token$toc_infos)
+    if (outline) add_outline(output, token$toc_infos)
     invisible(output)
   })
 }
@@ -228,7 +228,7 @@ find_gs = function() {
   'gs'
 }
 
-add_toc = function(pdf, toc_infos) {
+add_outline = function(pdf, toc_infos) {
   gs_file = tempfile()
   on.exit(unlink(gs_file), add = TRUE)
   writeLines(gen_toc_gs(toc_infos), con = gs_file)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -225,7 +225,15 @@ gen_toc_gs = function(toc) {
 
 ## TODO implement this for Windows, linux, and OSX
 find_gs = function() {
-  'gs'
+  gs = tools::find_gs_cmd()
+  # according to the doc of tools::find_gs_cmd, gs should always be a string
+  if (!nzchar(gs)) stop(
+    'Cannot find GhostScript executable automatically. ',
+    "Please pass the full path of the GhostScript executable ",
+    "to the environment variable 'R_GSCMD'. ",
+    "See ?tools::find_gs_cmd for more details."
+  )
+  unname(gs)
 }
 
 add_outline = function(pdf, toc_infos) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -45,7 +45,8 @@
 #'   \pkg{promises} package has to be installed in this case).
 #' @param outline If not \code{FALSE}, \code{chrome_print()} will add the bookmark
 #'   to the generated pdf file, based on the TOC info. It's enabled by default,
-#'   as long as the Ghostscript executable can be detected.
+#'   as long as the Ghostscript executable can be detected by
+#'   \code{\link[tools]{find_gs_cmd}}.
 #' @param encoding Not used. This argument is required by RStudio IDE.
 #' @references
 #' \url{https://developers.google.com/web/updates/2017/04/headless-chrome}

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -237,10 +237,11 @@ find_gs = function() {
 }
 
 add_outline = function(pdf, toc_infos) {
-  gs_file = tempfile()
-  on.exit(unlink(gs_file), add = TRUE)
-  writeLines(gen_toc_gs(toc_infos), con = gs_file)
-  output = tempfile(fileext = '.pdf')
+  gs_content = gen_toc_gs(toc_infos)
+  # when TOC doesn't exist, gs_content will be null
+  if (is.null(gs_content)) return(invisible(pdf))
+  gs_file = tempfile(); on.exit(unlink(gs_file), add = TRUE)
+  writeLines(gs_content, con = gs_file)
   gs = find_gs()
   if (xfun::isFALSE(gs)) stop(
     'Cannot find GhostScript executable automatically. ',
@@ -248,6 +249,7 @@ add_outline = function(pdf, toc_infos) {
     "to the environment variable 'R_GSCMD'. ",
     "See ?tools::find_gs_cmd for more details."
   )
+  output = tempfile(fileext = '.pdf')
   system2(
     gs,
     c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', pdf, gs_file),

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -43,6 +43,9 @@
 #' @param async Execute \code{chrome_print()} asynchronously? If \code{TRUE},
 #'   \code{chrome_print()} returns a \code{\link[promises]{promise}} value (the
 #'   \pkg{promises} package has to be installed in this case).
+#' @param outline If not \code{FALSE}, \code{chrome_print()} will add the bookmark
+#'   to the generated pdf file, based on the TOC info. It's enabled by default,
+#'   as long as the Ghostscript executable can be detected.
 #' @param encoding Not used. This argument is required by RStudio IDE.
 #' @references
 #' \url{https://developers.google.com/web/updates/2017/04/headless-chrome}

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -198,6 +198,9 @@ chrome_print = function(
     }
 
     if (is_rstudio_knit) message('\nOutput created: ', basename(output))
+
+    # attach the TOC info
+    attr(output, "toc") = token$toc
     invisible(output)
   })
 }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -219,7 +219,7 @@ gen_toc_gs = function(toc) {
     out = sprintf(template, count, title, page)
     if (any(count > 0L)) {
       children = lapply(x$children, to_gs)
-      out = unlist(Map(c, out, children), use.names = FALSE)
+      out = c(out, unlist(children, use.names = FALSE))
     }
     out
   }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -253,7 +253,7 @@ add_outline = function(pdf, toc_infos) {
   output = tempfile(fileext = '.pdf')
   system2(
     gs,
-    c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', pdf, gs_file),
+    shQuote(c('-o', output, '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/prepress', pdf, gs_file)),
     stdout = FALSE, stderr = FALSE
   )
   file.rename(output, pdf)

--- a/inst/resources/js/config.js
+++ b/inst/resources/js/config.js
@@ -111,10 +111,13 @@
     if (window.pagedownListener) {
       // the html file is opened for printing
       // call the binding to signal to the R session that Paged.js has finished
+      const tocList = flow.source.querySelector('.toc > ul');
+      const tocInfos = tocEntriesInfos(tocList);
       pagedownListener(JSON.stringify({
         pagedjs: true,
         pages: flow.total,
-        elapsedtime: flow.performance
+        elapsedtime: flow.performance,
+        tocInfos: tocInfos
       }));
       return;
     }

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -80,7 +80,8 @@ from the Chrome processes and WebSocket connections.}
 
 \item{outline}{If not \code{FALSE}, \code{chrome_print()} will add the bookmark
 to the generated pdf file, based on the TOC info. It's enabled by default,
-as long as the Ghostscript executable can be detected.}
+as long as the Ghostscript executable can be detected by
+\code{\link[tools]{find_gs_cmd}}.}
 
 \item{encoding}{Not used. This argument is required by RStudio IDE.}
 }

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -19,7 +19,7 @@ chrome_print(
   extra_args = c("--disable-gpu"),
   verbose = 0,
   async = FALSE,
-  outline = find_gs(),
+  outline = gs_available(),
   encoding
 )
 }
@@ -78,10 +78,11 @@ from the Chrome processes and WebSocket connections.}
 \code{chrome_print()} returns a \code{\link[promises]{promise}} value (the
 \pkg{promises} package has to be installed in this case).}
 
-\item{outline}{If not \code{FALSE}, \code{chrome_print()} will add the bookmark
-to the generated pdf file, based on the TOC info. It's enabled by default,
-as long as the Ghostscript executable can be detected by
-\code{\link[tools]{find_gs_cmd}}.}
+\item{outline}{If not \code{FALSE}, \code{chrome_print()} will add the bookmarks
+to the generated \code{pdf} file, based on the table of contents informations.
+This feature is only available for output formats based on
+\code{\link{html_paged}}. It is enabled by default, as long as the Ghostscript
+executable can be detected by \code{\link[tools]{find_gs_cmd}}.}
 
 \item{encoding}{Not used. This argument is required by RStudio IDE.}
 }

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -19,7 +19,7 @@ chrome_print(
   extra_args = c("--disable-gpu"),
   verbose = 0,
   async = FALSE,
-  toc = TRUE,
+  outline = find_gs(),
   encoding
 )
 }
@@ -77,6 +77,10 @@ from the Chrome processes and WebSocket connections.}
 \item{async}{Execute \code{chrome_print()} asynchronously? If \code{TRUE},
 \code{chrome_print()} returns a \code{\link[promises]{promise}} value (the
 \pkg{promises} package has to be installed in this case).}
+
+\item{outline}{If not \code{FALSE}, \code{chrome_print()} will add the bookmark
+to the generated pdf file, based on the TOC info. It's enabled by default,
+as long as the Ghostscript executable can be detected.}
 
 \item{encoding}{Not used. This argument is required by RStudio IDE.}
 }

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -19,6 +19,7 @@ chrome_print(
   extra_args = c("--disable-gpu"),
   verbose = 0,
   async = FALSE,
+  toc = TRUE,
   encoding
 )
 }

--- a/tests/test-cran/test-utils.R
+++ b/tests/test-cran/test-utils.R
@@ -12,3 +12,30 @@ assert('check_css() validates CSS file paths', {
   (is.null(check_css(c('default', 'letter'))))
   (has_error(check_css('default2'), silent = TRUE))
 })
+
+assert('gen_toc_gs() works', {
+  (gen_toc_gs(list()) %==% NULL)
+  toc = list(list(title = 'a', page = 3, children = list()))
+  res = '[/Count 0 /Title <a> /Page 3 /OUT pdfmark'
+  (gen_toc_gs(toc) %==% res)
+  toc = list(
+    list(title = 'a', page = 3, children = list(
+      list(title = 'a-1', page = 5, children = list()),
+      list(title = 'a-2', page = 8, children = list(
+        list(title = 'a-2-1', page = 9, children = list()),
+        list(title = 'a-2-2', page = 10, children = list())
+      ))
+    )),
+    list(title = 'b', page = 20, children = list())
+  )
+  res = c(
+    "[/Count 2 /Title <a> /Page 3 /OUT pdfmark",
+    "[/Count 0 /Title <a-1> /Page 5 /OUT pdfmark",
+    "[/Count 2 /Title <a-2> /Page 8 /OUT pdfmark",
+    "[/Count 0 /Title <a-2-1> /Page 9 /OUT pdfmark",
+    "[/Count 0 /Title <a-2-2> /Page 10 /OUT pdfmark",
+    "[/Count 0 /Title <b> /Page 20 /OUT pdfmark"
+  )
+  (gen_toc_gs(toc) %==% res)
+})
+

--- a/tests/test-cran/test-utils.R
+++ b/tests/test-cran/test-utils.R
@@ -15,9 +15,12 @@ assert('check_css() validates CSS file paths', {
 
 assert('gen_toc_gs() works', {
   (gen_toc_gs(list()) %==% NULL)
+
   toc = list(list(title = 'a', page = 3, children = list()))
   res = '[/Count 0 /Title <a> /Page 3 /OUT pdfmark'
+
   (gen_toc_gs(toc) %==% res)
+
   toc = list(
     list(title = 'a', page = 3, children = list(
       list(title = 'a-1', page = 5, children = list()),
@@ -36,6 +39,7 @@ assert('gen_toc_gs() works', {
     "[/Count 0 /Title <a-2-2> /Page 10 /OUT pdfmark",
     "[/Count 0 /Title <b> /Page 20 /OUT pdfmark"
   )
+
   (gen_toc_gs(toc) %==% res)
 })
 

--- a/tests/test-travis.R
+++ b/tests/test-travis.R
@@ -1,11 +1,12 @@
 # run tests on Travis (these tests depend on Chrome)
 
-print_pdf = function(input) {
+print_pdf = function(input, output = tempfile(), async = FALSE) {
   chrome_print(
-    input, tempfile(),
+    input, output,
     # use --no-sandbox with travis
     # https://docs.travis-ci.com/user/chrome#sandboxing
-    extra_args = c('--disable-gpu', '--no-sandbox')
+    extra_args = c('--disable-gpu', '--no-sandbox'),
+    async = async
   )
 }
 

--- a/tests/test-travis/test-chrome.R
+++ b/tests/test-travis/test-chrome.R
@@ -37,3 +37,30 @@ assert('find_gs() finds Ghostscript executable', {
   (nzchar(find_gs()))
   (gs_available())
 })
+
+assert('chrome_print() generates expected outline', {
+  f = print_pdf('test-outline.Rmd')
+
+  (is_pdf(f))
+
+  toc = pdftools::pdf_toc(f)[[2L]]
+  res = list(
+    list(title = "1 Title 1", children = list()),
+    list(
+      title = "2 Title 2",
+      children = list(
+        list(title = "2.1 Title 2-1", children = list()),
+        list(title = "2.2 Title 2-2", children = list(
+          list(title = "2.2.1 Title 2-2-1", children = list()),
+          list(title = "2.2.2 Title 2-2-2",children = list())
+        ))
+      )
+    ),
+    list(title = "3 \u4e2d\u6587", children = list()),
+    list(title = "4 \u4e2d\u6587 \u5e26\u7a7a\u683c", children = list(
+      list(title = "4.1 \u4e2d\u6587\u6b21\u7ea7\u6807\u9898", children = list())
+    ))
+  )
+
+  (toc %==% res)
+})

--- a/tests/test-travis/test-chrome.R
+++ b/tests/test-travis/test-chrome.R
@@ -32,3 +32,8 @@ assert('chrome_print() works with reveal.js presentations', {
   first_page_text_content = pdftools::pdf_text(f)[1]
   (identical(first_page_text_content, 'Test reveal.js'))
 })
+
+assert('find_gs() finds Ghostscript executable', {
+  (nzchar(find_gs()))
+  (gs_available())
+})

--- a/tests/test-travis/test-chrome.R
+++ b/tests/test-travis/test-chrome.R
@@ -63,4 +63,25 @@ assert('chrome_print() generates expected outline', {
   )
 
   (toc %==% res)
+
+  # works for async
+  f = print_pdf('test-outline.Rmd', async = TRUE)
+  (is_pdf(f))
+  toc = pdftools::pdf_toc(f)[[2L]]
+  (toc %==% res)
+
+  # works for output name with non-ASCII & white space
+  output = tempfile(pattern = "\u4e2d \u6587")
+  f = print_pdf('test-outline.Rmd', output = output)
+  (is_pdf(f))
+  toc = pdftools::pdf_toc(f)[[2L]]
+  (toc %==% res)
+
+  # works for input name with non-ASCII & white space
+  input = tempfile(pattern = "\u4e2d \u6587", fileext = '.Rmd')
+  file.copy('test-outline.Rmd', input)
+  f = print_pdf(input)
+  (is_pdf(f))
+  toc = pdftools::pdf_toc(f)[[2L]]
+  (toc %==% res)
 })

--- a/tests/test-travis/test-chrome.R
+++ b/tests/test-travis/test-chrome.R
@@ -65,10 +65,13 @@ assert('chrome_print() generates expected outline', {
   (toc %==% res)
 
   # works for async
+  # not sure it's the right way to test the promise object
   f = print_pdf('test-outline.Rmd', async = TRUE)
-  (is_pdf(f))
-  toc = pdftools::pdf_toc(f)[[2L]]
-  (toc %==% res)
+  out = promises::then(f, function(f) {
+    stopifnot(is_pdf(f))
+    toc = pdftools::pdf_toc(f)[[2L]]
+    stopifnot(toc %==% res)
+  })
 
   # works for output name with non-ASCII & white space
   output = tempfile(pattern = "\u4e2d \u6587")

--- a/tests/test-travis/test-outline.Rmd
+++ b/tests/test-travis/test-outline.Rmd
@@ -1,0 +1,47 @@
+---
+title: "A pagedown report with outlines"
+author: "Yihui Xie and Romain Lesur"
+date: "`r Sys.Date()`"
+output:
+  pagedown::html_paged:
+    toc: true
+    self_contained: false
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+# Title 1
+
+Some content of title 1
+
+# Title 2
+
+## Title 2-1
+
+Good
+
+## Title 2-2
+
+Wow
+
+### Title 2-2-1
+
+sub section
+
+### Title 2-2-2
+
+some words
+
+# 中文 {#chinese1}
+
+pagedown 不错
+
+# 中文 带空格 {#chinese2}
+
+很喜欢
+
+## 中文次级标题 {#chinese2-1}
+
+nice


### PR DESCRIPTION
Closes #174 

### TODO

- [x] try to find Ghostscript on different OS
- [x] print a useful message when Ghostscript can't be found
- [x] be sure that the pdf can be rendered when there's no TOC
- [x] be sure it works for non-ASCII on Windows
- [x] documentation

### MoreTODO

- [x] allows white space in the file name
- [x] works for `async = TRUE`
- [x] Support non-ASCII file name 
- [x] suppress the gs' output
- [x] fix the bug when a section contains multiple subsections
- [x] add some tests
    - [x] allows white space in section name
    - [x] allows non-ascii (despite now we have to use a ascii-identifier)
    - [x] ok with non-ascii file name
    - [x] ok with white space in file name
    - [x] ok with async

### The proto's output

<img width="846" alt="image" src="https://user-images.githubusercontent.com/8368933/83951659-b6c8d600-a865-11ea-8ea3-221f8a8f698e.png">


### Future feature (for myself)

I prefer the `outline` argument supports a `list` input to support more tailor-made features (like the below two). However, I think they are better to be addressed in a separate PR.

- be able to config the bookmark's status (open / close, with/without the section number)
- be able to display the bookmark only but not the TOC in the content


