### PR TITLE
deactivate anchor sections by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## BUG FIXES
 
+- The option `anchor_sections` is disabled internally. This option is for `rmarkdown::html_document()` to generate anchor links for sections and currently it does not work well for **pagedown** format for now (#195).
+
 - In `chrome_print()`, fixed a bug when the R session temporary directory and the current directory are mounted on different Linux file systems. In that case, `chrome_print()` failed to add an outline to the PDF and raised the warning `cannot rename file ..., reason 'Invalid cross-device link'` (#193). 
 
 # CHANGES IN pagedown VERSION 0.12

--- a/R/paged.R
+++ b/R/paged.R
@@ -131,7 +131,7 @@ pagedown_dependency = function(css = NULL, js = FALSE, .test = FALSE) {
 }
 
 html_format = function(
-  ..., self_contained = TRUE, mathjax = 'default', css, template, pandoc_args = NULL,
+  ..., self_contained = TRUE, anchor_sections = FALSE, mathjax = 'default', css, template, pandoc_args = NULL,
   .dependencies = NULL, .pagedjs = FALSE, .pandoc_args = NULL, .test = FALSE
 ) {
   if (!identical(mathjax, 'local')) {
@@ -164,7 +164,7 @@ html_format = function(
     ))
   }
   html_document2(
-    ..., self_contained = self_contained, mathjax = mathjax, css = css,
+    ..., self_contained = self_contained, anchor_sections = anchor_sections, mathjax = mathjax, css = css,
     template = template, pandoc_args = pandoc_args
   )
 }


### PR DESCRIPTION
Will fix #194 for now. 

We'll need to make anchor sections compatible with pagedown if we want to offer the option to the user.