### PR TITLE
[chrome_print] add support for PDF streaming

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.13.5
+Version: 0.13.6
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - Parts titles in the table of contents no longer crash `chrome_print()`.
 
+- `chrome_print()` is now compatible with the stream transfer mode which can be used to generate large PDF files (#205).
+
 # CHANGES IN pagedown VERSION 0.13
 
 ## NEW FEATURES

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -571,6 +571,9 @@ print_page = function(
         # Command #17 received
         # if there is another chunk to read -> callback: IO.read
         # if EOF -> callback: command #18 IO.close
+        if (verbose >= 1) message(
+          'Stream chunk received\n'
+        )
         if (isTRUE(msg$result$base64Encoded)) {
           writeBin(jsonlite::base64_dec(msg$result$data), con)
         } else {
@@ -578,6 +581,9 @@ print_page = function(
         }
 
         if (isTRUE(msg$result$eof)) {
+          if (verbose >= 1) message(
+            'No more stream chunk to read: closing Chrome stream\n'
+          )
           close(con)
           ws$send(to_json(list(
             id = 18, sessionId = session_id, method = 'IO.close',

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -555,9 +555,7 @@ print_page = function(
           resolve(output)
           token$done = TRUE
         } else {
-          if (verbose >= 1) message(
-            'Reading PDF from a stream\n'
-          )
+          if (verbose >= 1) message('Reading PDF from a stream')
           # open a connection
           con <<- file(output, 'wb')
           # read the first chunk of the stream
@@ -571,9 +569,7 @@ print_page = function(
         # Command #17 received
         # if there is another chunk to read -> callback: IO.read
         # if EOF -> callback: command #18 IO.close
-        if (verbose >= 1) message(
-          'Stream chunk received\n'
-        )
+        if (verbose >= 1) message('Stream chunk received')
         if (isTRUE(msg$result$base64Encoded)) {
           writeBin(jsonlite::base64_dec(msg$result$data), con)
         } else {
@@ -582,7 +578,7 @@ print_page = function(
 
         if (isTRUE(msg$result$eof)) {
           if (verbose >= 1) message(
-            'No more stream chunk to read: closing Chrome stream\n'
+            'No more stream chunk to read: closing Chrome stream'
           )
           close(con)
           ws$send(to_json(list(

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -405,6 +405,8 @@ print_page = function(
   session_id = NULL
   coords = NULL
   toc_infos = NULL
+  stream_handle = NULL
+  con = NULL
 
   ws$onOpen(function(event) {
     # Create a new Target (tab)
@@ -544,8 +546,53 @@ print_page = function(
         )))
       },
       {
-        # Command #16 received (printToPDF or captureScreenshot) -> callback: save to file & close Chrome
-        writeBin(jsonlite::base64_dec(msg$result$data), output)
+        # Command #16 received (printToPDF or captureScreenshot)
+        # if data are received -> callback: save to file & close Chrome
+        # if a stream handle is received -> callback: command #17 IO.read
+        if (is.null(stream_handle <<- msg$result$stream)) {
+          writeBin(jsonlite::base64_dec(msg$result$data), output)
+          if (!xfun::isFALSE(outline) && length(toc_infos)) add_outline(output, toc_infos, verbose)
+          resolve(output)
+          token$done = TRUE
+        } else {
+          if (verbose >= 1) message(
+            'Reading PDF from a stream\n'
+          )
+          # open a connection
+          con <<- file(output, 'wb')
+          # read the first chunk of the stream
+          ws$send(to_json(list(
+            id = 17, sessionId = session_id, method = 'IO.read',
+            params = list(handle = stream_handle)
+          )))
+        }
+      },
+      {
+        # Command #17 received
+        # if there is another chunk to read -> callback: IO.read
+        # if EOF -> callback: command #18 IO.close
+        if (isTRUE(msg$result$base64Encoded)) {
+          writeBin(jsonlite::base64_dec(msg$result$data), con)
+        } else {
+          writeBin(msg$result$data, con)
+        }
+
+        if (isTRUE(msg$result$eof)) {
+          close(con)
+          ws$send(to_json(list(
+            id = 18, sessionId = session_id, method = 'IO.close',
+            params = list(handle = stream_handle)
+          )))
+        } else {
+          # read another chunk
+          ws$send(to_json(list(
+            id = 17, sessionId = session_id, method = 'IO.read',
+            params = list(handle = stream_handle)
+          )))
+        }
+      },
+      {
+        # Command #18 received -> callback: add outline & close Chrome
         if (!xfun::isFALSE(outline) && length(toc_infos)) add_outline(output, toc_infos, verbose)
         resolve(output)
         token$done = TRUE

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -160,6 +160,31 @@ docker run -e PASSWORD=yourpassword --rm -p 8787:8787 --security-opt seccomp="$(
 
 With this seccomp file, you do not have to use the `"--no-sandbox"` option: this is much more secure!
 
+### Troubleshooting with large PDF files generation
+
+If your document contains a lot of images `chrome_print()` can fail to generate your PDF.  
+For example, you may obtain the following error message:
+
+```
+[error] consume error: websocketpp.processor.4 (A message was too large)
+```
+
+In that case, you need to use a different mean of communication between Chrome and R by changing the `transferMode` option:
+
+```r
+chrome_print(..., options = list(transferMode = "ReturnAsStream"))
+```
+
+On Linux environments with minimal resources (like a container), you also can get this error message:
+
+```
+Chrome crashed.
+This may be caused by insufficient resources.
+Please, try to add "--disable-dev-shm-usage" to the `extra_args` argument.
+```
+
+Here, you just have to follow the advice and add `"--disable-dev-shm-usage"` to the `extra_args` argument of `chrome_print()`. 
+
 # Applications 
 
 ## Resume

--- a/tests/test-travis.R
+++ b/tests/test-travis.R
@@ -1,12 +1,12 @@
 # run tests on Travis (these tests depend on Chrome)
 
-print_pdf = function(input, output = tempfile(), async = FALSE) {
+print_pdf = function(input, output = tempfile(), ...) {
   chrome_print(
     input, output,
     # use --no-sandbox with travis
     # https://docs.travis-ci.com/user/chrome#sandboxing
     extra_args = c('--disable-gpu', '--no-sandbox'),
-    async = async
+    ...
   )
 }
 

--- a/tests/test-travis/test-chrome.R
+++ b/tests/test-travis/test-chrome.R
@@ -41,6 +41,13 @@ assert('chrome_print() works with a local file path', {
   (is_pdf(print_pdf(r_faq_html)))
 })
 
+assert('chrome_print() supports PDF streaming', {
+  r_faq_html = file.path(R.home('doc'), 'manual', 'R-FAQ.html')
+
+  (is_pdf(print_pdf(r_faq_html, options = list(transferMode = 'ReturnAsStream'))))
+})
+
+
 assert('chrome_print() works with html_paged format', {
   (is_pdf(print_pdf('test-chrome.Rmd')))
 })


### PR DESCRIPTION
The aim of this PR is to add support for PDF streaming in `chrome_print()`.

For now, very large PDF lead to a websocket error: 

```
[error] consume error: websocketpp.processor.4 (A message was too large)
```

The [Page.printToPDF](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF) method has an experimental feature to return the PDF as a stream: `transferMode = "ReturnAsStream"`.

With this PR, one can print a PDF with the stream transfer mode:

``` r
chrome_print(..., options = list(transferMode = "ReturnAsStream"))
```

**TODO**

- [x] write a test
- [x] implement stream support
- [x] test the generation of very large PDF files (more than one chunk)  
    Edit: tested with a 24 MB PDF file (4 stream chunks)
- [ ] ~add support for the chunk `size` parameter (see [IO.read](https://chromedevtools.github.io/devtools-protocol/tot/IO/#method-read))~  
    Edit: after several tests, I think this is useless, the `websocket` package works fine
- [x] update documentation  
