### PR TITLE
[chrome_print] change the default transfer mode for PDF printing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.14.3
+Version: 0.14.4
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.14.1
+Version: 0.14.2
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN pagedown VERSION 0.15
 
+## MAJOR CHANGES
+
+- In `chrome_print()`, when printing a document to PDF, the default transfer mode between Chrome and R now uses a stream when this option is available in Chrome. This change ensures that PDF files of any size can be generated (#206 and #224).
 
 # CHANGES IN pagedown VERSION 0.14
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -73,6 +73,8 @@ chrome_print = function(
     !missing(encoding) && length(match.call()) == 3
   if (is_rstudio_knit) verbose = 1
 
+  format = match.arg(format)
+
   if (missing(browser) && is.na(browser <- Sys.getenv('PAGEDOWN_CHROME', NA))) {
     browser = find_chrome()
   } else {
@@ -163,7 +165,6 @@ chrome_print = function(
       url = svr$url
     } else url = input  # the input is not a local file; assume it is just a URL
 
-    format = match.arg(format)
     # remove hash/query parameters in url
     if (missing(output) && !file.exists(input))
       output = xfun::with_ext(basename(gsub('[#?].*', '', url)), format)

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -172,29 +172,23 @@ With this seccomp file, you do not have to use the `"--no-sandbox"` option: this
 
 ### Troubleshooting with large PDF files generation
 
-If your document contains a lot of images `chrome_print()` can fail to generate your PDF.  
-For example, you may obtain the following error message:
+In rare circumstances and if your document contains a lot of images, `chrome_print()` may fail to generate your PDF.
 
-```
-[error] consume error: websocketpp.processor.4 (A message was too large)
-```
-
-In that case, you need to use a different mean of communication between Chrome and R by changing the `transferMode` option:
-
-```r
-chrome_print(
-  ...,
-  options = list(transferMode = "ReturnAsStream")
-)
-```
-
-On Linux environments with minimal resources (like a container), you also can get this error message:
+On Linux environments with minimal resources (like a container), you may get this error message:
 
 ```
 Chrome crashed. This may be caused by insufficient resources. Please, try to add "--disable-dev-shm-usage" to the `extra_args` argument.
 ```
 
-Here, you just have to follow the advice!
+Here, you just have to follow the advice.
+
+If you use an old version of Chrome, you may obtain the following error message:
+
+```
+[error] consume error: websocketpp.processor.4 (A message was too large)
+```
+
+In that case, you must install a more recent version of Chrome.
 
 # Applications 
 

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -57,8 +57,9 @@ not set.}
  for the full list of options for PDF output, and
 \code{https://chromedevtools.github.io/devtools-protocol/tot/Page#method-captureScreenshot}
  for options for screenshots. Note that for PDF output, we have changed the
-defaults of \code{printBackground} (\code{TRUE}) and
-\code{preferCSSPageSize} (\code{TRUE}) in this function.}
+defaults of \code{printBackground} (\code{TRUE}),
+\code{preferCSSPageSize} (\code{TRUE}) and when available
+\code{transferMode} (\code{ReturnAsStream}) in this function.}
 
 \item{selector}{A CSS selector used when capturing a screenshot.}
 


### PR DESCRIPTION
This PR modifies the default transfer mode when printing to PDF in order to use a stream by default.
Therefore, PDF files of **any size** can now be produced without any user action.

close #206 