### PR TITLE
Add support for Edge on windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.14.4
+Version: 0.14.5
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN pagedown VERSION 0.15
 
+## NEW FEATURES
+
+- `find_chrome()` now searches for Microsoft Edge on windows. That allows `chrome_print()` to work seamlessly with Microsoft Edge (thanks, @cderv, #160 and #225).    
+
 ## MINOR CHANGES
 
 - Multiple `knitr::kables()` are now vertically aligned by default in `html_paged()`, `thesis_paged()` and `jss_paged()` output formats (thanks, @cderv and @andrew-fuller, #214).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- `find_chrome()` now searches for Microsoft Edge on windows. That allows `chrome_print()` to work seamlessly with Microsoft Edge (thanks, @cderv, #160 and #225).    
+- `find_chrome()` now searches for Microsoft Edge on Windows. That allows `chrome_print()` to work seamlessly with Microsoft Edge (thanks, @cderv, #160 and #225).    
 
 ## MINOR CHANGES
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -284,17 +284,19 @@ find_chrome = function() {
   switch(
     .Platform$OS.type,
     windows = {
-      res = tryCatch({
-        unlist(utils::readRegistry('ChromeHTML\\shell\\open\\command', 'HCR'))
-      }, error = function(e) '')
-      res = unlist(strsplit(res, '"'))
-      res = head(res[file.exists(res)], 1)
-      if (length(res) != 1) stop(
-        'Cannot find Google Chrome automatically from the Windows Registry Hive. ',
-        "Please pass the full path of chrome.exe to the 'browser' argument ",
+      res = unlist(lapply(c('ChromeHTML', 'MSEdgeHTM'), function(x) {
+        res = tryCatch({
+          unlist(utils::readRegistry(sprintf('%s\\shell\\open\\command', x), 'HCR'))
+        }, error = function(e) '')
+        res = unlist(strsplit(res, '"'))
+        res = head(res[file.exists(res)], 1)
+      }))
+      if (length(res) < 1) stop(
+        'Cannot find Google Chrome or Edge automatically from the Windows Registry Hive. ',
+        "Please pass the full path of chrome.exe or msedge.exe to the 'browser' argument ",
         "or to the environment variable 'PAGEDOWN_CHROME'."
       )
-      res
+      res[1]
     },
     unix = if (xfun::is_macos()) {
       '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -1,8 +1,8 @@
 #' Print a web page to PDF or capture a screenshot using the headless Chrome
 #'
 #' Print an HTML page to PDF or capture a PNG/JPEG screenshot through the Chrome
-#' DevTools Protocol. Google Chrome (or Chromium on Linux) must be installed
-#' prior to using this function.
+#' DevTools Protocol. Google Chrome or Microsoft Edge (or Chromium on Linux)
+#' must be installed prior to using this function.
 #' @param input A URL or local file path to an HTML page, or a path to a local
 #'   file that can be rendered to HTML via \code{rmarkdown::\link{render}()}
 #'   (e.g., an R Markdown document or an R script). If the \code{input} is to be
@@ -21,10 +21,10 @@
 #'   printing (in certain cases, the page may not be immediately ready for
 #'   printing, especially there are JavaScript applications on the page, so you
 #'   may need to wait for a longer time).
-#' @param browser Path to Google Chrome or Chromium. This function will try to
-#'   find it automatically via \code{\link{find_chrome}()} if the path is not
-#'   explicitly provided and the environment variable \code{PAGEDOWN_CHROME} is
-#'   not set.
+#' @param browser Path to Google Chrome, Microsoft Edge or Chromium. This
+#'   function will try to find it automatically via \code{\link{find_chrome}()}
+#'   if the path is not explicitly provided and the environment variable
+#'   \code{PAGEDOWN_CHROME} is not set.
 #' @param format The output format.
 #' @param options A list of page options. See
 #'   \code{https://chromedevtools.github.io/devtools-protocol/tot/Page#method-printToPDF}
@@ -272,12 +272,12 @@ add_outline = function(input, toc_infos, verbose) {
   invisible(input)
 }
 
-#' Find Google Chrome or Chromium in the system
+#' Find Google Chrome, Microsoft Edge or Chromium in the system
 #'
-#' On Windows, this function tries to find Chrome from the registry. On macOS,
-#' it returns a hard-coded path of Chrome under \file{/Applications}. On Linux,
-#' it searches for \command{chromium-browser} and \command{google-chrome} from
-#' the system's \var{PATH} variable.
+#' On Windows, this function tries to find Chrome or Edge from the registry. On
+#' macOS, it returns a hard-coded path of Chrome under \file{/Applications}. On
+#' Linux, it searches for \command{chromium-browser} and \command{google-chrome}
+#' from the system's \var{PATH} variable.
 #' @return A character string.
 #' @export
 find_chrome = function() {
@@ -622,7 +622,7 @@ print_page = function(
       }
       if (method == 'Runtime.exceptionThrown') {
         warning(
-          'A runtime exception has occured in Chrome\n',
+          'A runtime exception has occured while executing JavaScript\n',
           '  Runtime exception message:\n    ',
           msg$params$exceptionDetails$exception$description,
           call. = FALSE, immediate. = TRUE

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/rstudio/pagedown"><img src="https://user-images.githubusercontent.com/163582/51942716-66be4180-23dd-11e9-8dbc-fdb4f465d1c2.png" alt="pagedown logo" align="right" /></a>
 
-Paginate the HTML Output of R Markdown with CSS for Print. You only need a modern web browser (e.g., Google Chrome) to generate PDF. No need to install LaTeX to get beautiful PDFs.
+Paginate the HTML Output of R Markdown with CSS for Print. You only need a modern web browser (e.g., Google Chrome or Microsoft Edge) to generate PDF. No need to install LaTeX to get beautiful PDFs.
 
 This R package stands on the shoulders of two giants to support typesetting with CSS for R Markdown documents: [Paged.js](https://gitlab.pagedmedia.org/tools/pagedjs) and [ReLaXed](https://github.com/RelaxedJS/ReLaXed) (we only borrowed some CSS from the ReLaXed repo and didn't really use the Node package).
 

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -94,9 +94,9 @@ Note that this overriding mechanism also works for other output formats in **pag
 
 There are three ways to print to PDF:
 
-1. with Google Chrome or Chromium using the menu "Print" or by pressing `Ctrl + P` (or `Command + P` on macOS). Remember to allow background graphics to be printed.
+1. with Google Chrome, Microsoft Edge or Chromium using the menu "Print" or by pressing `Ctrl + P` (or `Command + P` on macOS). Remember to allow background graphics to be printed.
 
-1. using the function `chrome_print()`. Its first argument (`input`) accepts a path to a local Rmd or HTML file or an URL. Google Chrome or Chromium must be installed on your system.
+1. using the function `chrome_print()`. Its first argument (`input`) accepts a path to a local Rmd or HTML file or an URL. Google Chrome, Microsoft Edge or Chromium must be installed on your system.
 
 1. in RStudio, adding the following line in the YAML header of your Rmd file:
 
@@ -105,7 +105,7 @@ There are three ways to print to PDF:
    ```
    
    With this metadata parameter, the behavior of the "Knit" button of RStudio is modified: it produces both the HTML document and the PDF with Chrome. This functionality is suitable for any R Markdown HTML output format and is mainly convenient for small documents like presentations or notes.  
-   If `chrome_print()` cannot find Chrome or Chromium automatically, set the `PAGEDOWN_CHROME` environment variable to the path to Chrome or Chromium executable. 
+   If `chrome_print()` cannot find Chrome, Edge or Chromium automatically, set the `PAGEDOWN_CHROME` environment variable to the path to Chrome, Edge or Chromium executable. 
 
 ### Print to PDF on a server
 

--- a/man/chrome_print.Rd
+++ b/man/chrome_print.Rd
@@ -45,10 +45,10 @@ printing (in certain cases, the page may not be immediately ready for
 printing, especially there are JavaScript applications on the page, so you
 may need to wait for a longer time).}
 
-\item{browser}{Path to Google Chrome or Chromium. This function will try to
-find it automatically via \code{\link{find_chrome}()} if the path is not
-explicitly provided and the environment variable \code{PAGEDOWN_CHROME} is
-not set.}
+\item{browser}{Path to Google Chrome, Microsoft Edge or Chromium. This
+function will try to find it automatically via \code{\link{find_chrome}()}
+if the path is not explicitly provided and the environment variable
+\code{PAGEDOWN_CHROME} is not set.}
 
 \item{format}{The output format.}
 
@@ -98,8 +98,8 @@ Path of the output file (invisibly). If \code{async} is \code{TRUE},
 }
 \description{
 Print an HTML page to PDF or capture a PNG/JPEG screenshot through the Chrome
-DevTools Protocol. Google Chrome (or Chromium on Linux) must be installed
-prior to using this function.
+DevTools Protocol. Google Chrome or Microsoft Edge (or Chromium on Linux)
+must be installed prior to using this function.
 }
 \references{
 \url{https://developers.google.com/web/updates/2017/04/headless-chrome}

--- a/man/find_chrome.Rd
+++ b/man/find_chrome.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/chrome.R
 \name{find_chrome}
 \alias{find_chrome}
-\title{Find Google Chrome or Chromium in the system}
+\title{Find Google Chrome, Microsoft Edge or Chromium in the system}
 \usage{
 find_chrome()
 }
@@ -10,8 +10,8 @@ find_chrome()
 A character string.
 }
 \description{
-On Windows, this function tries to find Chrome from the registry. On macOS,
-it returns a hard-coded path of Chrome under \file{/Applications}. On Linux,
-it searches for \command{chromium-browser} and \command{google-chrome} from
-the system's \var{PATH} variable.
+On Windows, this function tries to find Chrome or Edge from the registry. On
+macOS, it returns a hard-coded path of Chrome under \file{/Applications}. On
+Linux, it searches for \command{chromium-browser} and \command{google-chrome}
+from the system's \var{PATH} variable.
 }


### PR DESCRIPTION
This PR adds the support for Edge on windows in `find_chrome()`.

Close #160 