### PR TITLE
Handle table header in multiple pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - Added support for Sass files with `.scss` and `.sass` extension (thanks, @felipecrp, #244).
 
+- Added support for long tables, i.e., repeat the table header when a page break the table. (thanks, @felipecrp, #250).
+
 # CHANGES IN pagedown VERSION 0.15
 
 ## NEW FEATURES

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 - Added support for Sass files with `.scss` and `.sass` extension (thanks, @felipecrp, #244).
 
-- Added support for long tables, i.e., repeat the table header when a page break the table. (thanks, @felipecrp, #250).
+- Added support for long tables, i.e., repeat the table header when a page breaks the table. (thanks, @felipecrp, #250).
 
 # CHANGES IN pagedown VERSION 0.15
 

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -552,4 +552,154 @@
       });
     }
   });
+
+  Paged.registerHandlers(class RepeatingTableHeadersHandler extends Paged.Handler {
+
+    constructor(chunker, polisher, caller) {
+        super(chunker, polisher, caller);
+        this.splitTablesRefs = [];
+    }
+
+    afterPageLayout(pageElement, page, breakToken, chunker) {
+        this.chunker = chunker;
+        this.splitTablesRefs = [];
+
+        if (breakToken) {
+            const node = breakToken.node;
+            const tables = this.findAllAncestors(node, "table");
+            if (node.tagName === "TABLE") {
+                tables.push(node);
+            }
+
+            if (tables.length > 0) {
+                this.splitTablesRefs = tables.map(t => t.dataset.ref);
+
+                //checks if split inside thead and if so, set breakToken to next sibling element
+                let thead = node.tagName === "THEAD" ? node : this.findFirstAncestor(node, "thead");
+                if (thead) {
+                    let lastTheadNode = thead.hasChildNodes() ? thead.lastChild : thead;
+                    breakToken.node = this.nodeAfter(lastTheadNode, chunker.source);
+                }
+
+                this.hideEmptyTables(pageElement, node);
+            }
+        }
+    }
+
+    hideEmptyTables(pageElement, breakTokenNode) {
+        this.splitTablesRefs.forEach(ref => {
+            let table = pageElement.querySelector("[data-ref='" + ref + "']");
+            if (table) {
+                let sourceBody = table.querySelector("tbody > tr");
+                if (!sourceBody || this.refEquals(sourceBody.firstElementChild, breakTokenNode)) {
+                    table.style.visibility = "hidden";
+                    table.style.position = "absolute";
+                    let lineSpacer = table.nextSibling;
+                    if (lineSpacer) {
+                        lineSpacer.style.visibility = "hidden";
+                        lineSpacer.style.position = "absolute";
+                    }
+                }
+            }
+        });
+    }
+
+    refEquals(a, b) {
+        return a && a.dataset && b && b.dataset && a.dataset.ref === b.dataset.ref;
+    }
+
+    findFirstAncestor(element, selector) {
+        while (element.parentNode && element.parentNode.nodeType === 1) {
+            if (element.parentNode.matches(selector)) {
+                return element.parentNode;
+            }
+            element = element.parentNode;
+        }
+        return null;
+    }
+
+    findAllAncestors(element, selector) {
+        const ancestors = [];
+        while (element.parentNode && element.parentNode.nodeType === 1) {
+            if (element.parentNode.matches(selector)) {
+                ancestors.unshift(element.parentNode);
+            }
+            element = element.parentNode;
+        }
+        return ancestors;
+    }
+
+    // The addition of repeating Table Headers is done here because this hook is triggered before overflow handling
+    layout(rendered, layout) {
+        this.splitTablesRefs.forEach(ref => {
+            const renderedTable = rendered.querySelector("[data-ref='" + ref + "']");
+            if (renderedTable) {
+                // this event can be triggered multiple times
+                // added a flag repeated-headers to control when table headers already repeated in current page.
+                if (!renderedTable.getAttribute("repeated-headers")) {
+                    const sourceTable = this.chunker.source.querySelector("[data-ref='" + ref + "']");
+                    this.repeatColgroup(sourceTable, renderedTable);
+                    this.repeatTHead(sourceTable, renderedTable);
+                    renderedTable.setAttribute("repeated-headers", true);
+                }
+            }
+        });
+    }
+
+    repeatColgroup(sourceTable, renderedTable) {
+        let colgroup = sourceTable.querySelectorAll("colgroup");
+        let firstChild = renderedTable.firstChild;
+        colgroup.forEach((colgroup) => {
+            let clonedColgroup = colgroup.cloneNode(true);
+            renderedTable.insertBefore(clonedColgroup, firstChild);
+        });
+    }
+
+    repeatTHead(sourceTable, renderedTable) {
+        let thead = sourceTable.querySelector("thead");
+        if (thead) {
+            let clonedThead = thead.cloneNode(true);
+            renderedTable.insertBefore(clonedThead, renderedTable.firstChild);
+        }
+    }
+
+    // the functions below are from pagedjs utils/dom.js
+    nodeAfter(node, limiter) {
+        if (limiter && node === limiter) {
+            return;
+        }
+        let significantNode = this.nextSignificantNode(node);
+        if (significantNode) {
+            return significantNode;
+        }
+        if (node.parentNode) {
+            while ((node = node.parentNode)) {
+                if (limiter && node === limiter) {
+                    return;
+                }
+                significantNode = this.nextSignificantNode(node);
+                if (significantNode) {
+                    return significantNode;
+                }
+            }
+        }
+    }
+
+    nextSignificantNode(sib) {
+        while ((sib = sib.nextSibling)) {
+            if (!this.isIgnorable(sib)) return sib;
+        }
+        return null;
+    }
+
+    isIgnorable(node) {
+        return (node.nodeType === 8) || // A comment node
+            ((node.nodeType === 3) && this.isAllWhitespace(node)); // a text node, all whitespace
+    }
+
+    isAllWhitespace(node) {
+        return !(/[^\t\n\r ]/.test(node.textContent));
+    }
+  });
+
 }

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -552,7 +552,9 @@
       });
     }
   });
-
+  // Repeat table headers on multiple pages
+  // Authors: Julien Taquet, Lucas Maciuga and Tafael Caixeta, see https://gitlab.pagedmedia.org/tools/pagedjs/issues/84
+  // TODO: remove this hook when Paged.js integrates this feature
   Paged.registerHandlers(class RepeatingTableHeadersHandler extends Paged.Handler {
 
     constructor(chunker, polisher, caller) {

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -552,6 +552,7 @@
       });
     }
   });
+
   // Repeat table headers on multiple pages
   // Authors: Julien Taquet, Lucas Maciuga and Tafael Caixeta, see https://gitlab.pagedmedia.org/tools/pagedjs/issues/84
   // TODO: remove this hook when Paged.js integrates this feature


### PR DESCRIPTION
This PR resolves #162. It uses a paged.js hook to repeat the table header when a page breaks the table.

The original javascript code was developed by Julien (@julientaq) and improved by Lucas Maciuga and Tafael Caixeta (@tafael) on an issue of the paged.js library (https://gitlab.pagedmedia.org/tools/pagedjs/issues/84).

I just integrated the code into pagedown. I also tested the code with the following snippet.

    ---
    output:
      pagedown::html_paged
    ---
    
    ```{r, echo=FALSE, message=FALSE, results=FALSE}
    library(tidyverse)
    data(iris)
    ```
    
    # Table Test
    
    ```{r, echo=FALSE}
    iris %>% knitr::kable()
    ```

The result sounds good.

![image](https://user-images.githubusercontent.com/615155/141039172-fb4ad465-d635-47b0-b2e8-59f755c5a257.png)

