### PR TITLE
Use rmarkdown shared lua file to access common functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Description: Use the paged media properties in CSS and the JavaScript
   pages. Each page can have its page size, page numbers, margin boxes, and
   running headers, etc. Applications of this package include books, letters,
   reports, papers, business cards, resumes, and posters.
-Imports: rmarkdown (>= 2.8), bookdown (>= 0.8), htmltools, jsonlite, later (>= 1.0.0),
+Imports: rmarkdown (>= 2.11.12), bookdown (>= 0.8), htmltools, jsonlite, later (>= 1.0.0),
   processx, servr (>= 0.23), httpuv, xfun, websocket
 Suggests: 
     promises,
@@ -35,3 +35,4 @@ BugReports: https://github.com/rstudio/pagedown/issues
 SystemRequirements: Pandoc (>= 2.2.3)
 Encoding: UTF-8
 RoxygenNote: 7.1.1
+Remotes: rstudio/rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN pagedown VERSION 0.17
 
+- Fix an issue in `jss_paged()` with Pandoc 2.17 and above.
 
 # CHANGES IN pagedown VERSION 0.16
 

--- a/inst/resources/lua/jss.lua
+++ b/inst/resources/lua/jss.lua
@@ -8,6 +8,24 @@
 
     Developped using Pandoc 2.2.3 by @RLesur
 --]]
+
+-- REQUIREMENTS: Load shared lua function - see `shared.lua` in rmarkdown for more details.
+--  * pandocAvailable()
+--  * type() (backward compatible after 2.17 changes)
+--  * print_debug()
+dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
+
+--[[
+  About the requirement:
+  * PANDOC_VERSION -> 2.2.3
+]]
+if (not pandocAvailable {2,2,3}) then
+    io.stderr:write("[WARNING] (jss.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
+    return {}
+end
+
+-- START OF THE FILTER'S FUNCTIONS --
+
 local isInteger = function(number)
   return math.floor(number) == number
 end
@@ -48,20 +66,6 @@ local getDOI = function(volume, issue)
   return "10.18637/jss.v" .. padVolume(volumeNumber) .. ".i" .. padIssue(issueNumber)
 end
 
-isType = function(meta, pandocType)
-  -- Pandoc 2.17 changes the way Meta works
-  -- .t tags was used to detect Meta type like MetaList
-  -- pandoc.utils.type was introduced for this simplify the type to usual
-  -- pandoc ones e.g MetaList -> List
-  -- This function allow to support earlier and later versions
-  -- https://github.com/rstudio/pagedown/issues/268
-  if not pandoc.utils.type and meta.t then
-    return meta.t == "Meta"..pandocType
-  else
-    return pandoc.utils.type(meta) == pandocType
-  end
-end
-
 Meta = function(meta)
   ---------------------------------------
   --           Keywords                --
@@ -71,7 +75,7 @@ Meta = function(meta)
   -- Store plain keywords:
   local plainKeywords = {}
 
-  if isType(meta.keywords, "List") then
+  if type(meta.keywords) == "List" then
     for i, v in ipairs(meta.keywords) do
       plainKeywords[i] = pandoc.utils.stringify(v)
     end
@@ -87,7 +91,7 @@ Meta = function(meta)
   ---------------------------------------
   local author = meta.author
 
-  if isType(author, "Inlines") then
+  if type(author) == "Inlines" then
     meta.author = {data = author, rank = "1"}
   else
     for i, v in ipairs(author) do

--- a/inst/resources/lua/jss.lua
+++ b/inst/resources/lua/jss.lua
@@ -11,7 +11,7 @@
 
 -- REQUIREMENTS: Load shared lua function - see `shared.lua` in rmarkdown for more details.
 --  * pandocAvailable()
---  * type() (backward compatible after 2.17 changes)
+--  * pandoc_type() function (backward compatible type() after 2.17 changes)
 --  * print_debug()
 dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
 
@@ -75,7 +75,7 @@ Meta = function(meta)
   -- Store plain keywords:
   local plainKeywords = {}
 
-  if type(meta.keywords) == "List" then
+  if pandoc_type(meta.keywords) == "List" then
     for i, v in ipairs(meta.keywords) do
       plainKeywords[i] = pandoc.utils.stringify(v)
     end
@@ -91,7 +91,7 @@ Meta = function(meta)
   ---------------------------------------
   local author = meta.author
 
-  if type(author) == "Inlines" then
+  if pandoc_type(author) == "Inlines" then
     meta.author = {data = author, rank = "1"}
   else
     for i, v in ipairs(author) do


### PR DESCRIPTION
This is an update of #268 has we need to fix this in other repo too (e.g https://github.com/rstudio/bookdown/issues/1302)

It requires a newer rmarkdown but this should be a release soon. 

@RLesur pinging for review just so you are aware of this. I don't think it should cause issue. I am just trying to use the same workflow in all our Lua filter. I have updated only `jss.lua` for now which uses those functions