### PR TITLE
Fix duplicating headers in tables that force new page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN pagedown VERSION 0.17
 
+## BUG FIXES
+
+- Fix duplicating headers in tables that force new page (thanks, @Darxor, #272)
 
 # CHANGES IN pagedown VERSION 0.16
 

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -636,7 +636,7 @@
     layout(rendered, layout) {
         this.splitTablesRefs.forEach(ref => {
             const renderedTable = rendered.querySelector("[data-ref='" + ref + "']");
-            if (renderedTable) {
+            if (renderedTable && renderedTable.hasAttribute("data-split-from")) {
                 // this event can be triggered multiple times
                 // added a flag repeated-headers to control when table headers already repeated in current page.
                 if (!renderedTable.getAttribute("repeated-headers")) {


### PR DESCRIPTION
This PR fixes #265.

Issue was that hook went over breakTokens that also happened to be `<table>` tags, and did not check whether this breakToken was due to table actually splitting or due to `<table>` having `break-before: page;` property.

I my testing, adding a check for `data-split-from` attribute is enough.