### PR TITLE
Fix LOT / LOF with Pandoc 2.17+ 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,11 +24,12 @@ jobs:
       matrix:
         config:
           # testing R release with last shipped pandoc version in RStudio IDE and new pandoc
-          - {os: windows-latest, pandoc: '2.16.1',  r: 'release'}
-          - {os: macOS-latest,   pandoc: '2.16.1',  r: 'release'}
-          - {os: ubuntu-18.04,   pandoc: '2.16.1',  r: 'release'}
+          - {os: windows-latest, pandoc: '2.17.1.1',  r: 'release'}
+          - {os: macOS-latest,   pandoc: '2.17.1.1',  r: 'release'}
+          - {os: ubuntu-18.04,   pandoc: '2.17.1.1',  r: 'release'}
           - {os: ubuntu-18.04,   pandoc: 'devel',   r: 'release'}
           # # testing older pandoc versions
+          - {os: ubuntu-18.04,   pandoc: '2.16.1',  r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.14.2',  r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.11.4',  r: 'release'}
           # # testing other R versions

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Suggests:
     xaringan,
     pdftools,
     revealjs,
-    covr
+    covr,
+    xml2
 License: MIT + file LICENSE
 URL: https://github.com/rstudio/pagedown
 BugReports: https://github.com/rstudio/pagedown/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Fix an issue in `jss_paged()` with Pandoc 2.17 and above.
 
+- Fix an issue in `html_paged()` with LOT and LOF not showing anymore with Pandoc 2.17 and above (thanks, @adamvi, #280). 
+
 # CHANGES IN pagedown VERSION 0.17
 
 ## BUG FIXES

--- a/inst/resources/lua/loft.lua
+++ b/inst/resources/lua/loft.lua
@@ -143,4 +143,4 @@ local function appendLoft(doc)
   return pandoc.Pandoc(doc.blocks, doc.meta)
 end
 
-return {{Meta = getMeta}, {Div = addFigRef, Table = addTabRef, Doc = appendLoft}}
+return {{Meta = getMeta}, {Div = addFigRef, Table = addTabRef, Pandoc = appendLoft}}

--- a/tests/test-ci/test-features.R
+++ b/tests/test-ci/test-features.R
@@ -4,3 +4,54 @@ assert('Page breaks work', {
   f = print_pdf('test-page-breaks.Rmd')
   (identical(pdftools::pdf_info(f)$pages, 5L))
 })
+
+assert('lot / lof are inserted correctly', {
+  if (xfun::loadable("xml2")) {
+    dir.create(tmp_dir <- tempfile())
+    xfun::in_dir(tmp_dir, {
+      # use included template
+      rmarkdown::draft("test.Rmd", "html-paged", "pagedown", edit = FALSE)
+      # add lot / lof
+      xfun::gsub_file("test.Rmd", pattern = "^---$", replacement = "---\nlot: true\nlof: true")
+      res = rmarkdown::render("test.Rmd", quiet = TRUE)
+    })
+    content <- xml2::read_html(res, encoding = "UTF-8")
+    # correctly in TOC
+    toc <- xml2::xml_find_all(content, "//div[@id='TOC']")
+    toc_lot <- xml2::xml_find_all(toc, "ul/li/a[@href='#LOT']")
+    (length(toc_lot) == 1)
+    (xml2::xml_text(toc_lot) == "List of Tables")
+    toc_lof <- xml2::xml_find_all(toc, "ul/li/a[@href='#LOF']")
+    (length(toc_lof) == 1)
+    (xml2::xml_text(toc_lof) == "List of Figures")
+    # Correctly in top body
+    main <- xml2::xml_find_all(content, "//div[contains(@class, 'main')]")
+    divs <- xml2::xml_find_all(main, "div[@id]")
+    (xml2::xml_attr(divs[1], 'id') == "LOT")
+    (xml2::xml_attr(divs[2], 'id') == "LOF")
+
+    # Change titles
+    xfun::in_dir(tmp_dir, {
+      xfun::gsub_file("test.Rmd", pattern = "^---$",
+                      replacement = "---\nlot-title: Custom LOT\nlof-title: Custom LOF")
+      res = rmarkdown::render("test.Rmd", quiet = TRUE)
+    })
+    content <- xml2::read_html(res)
+    # correctly in TOC
+    toc <- xml2::xml_find_all(content, "//div[@id='TOC']")
+    toc_lot <- xml2::xml_find_all(toc, "ul/li/a[@href='#LOT']")
+    (length(toc_lot) == 1)
+    (xml2::xml_text(toc_lot) == "Custom LOT")
+    toc_lof <- xml2::xml_find_all(toc, "ul/li/a[@href='#LOF']")
+    (length(toc_lof) == 1)
+    (xml2::xml_text(toc_lof) == "Custom LOF")
+    # Correctly in top body
+    main <- xml2::xml_find_all(content, "//div[contains(@class, 'main')]")
+    h1 <- xml2::xml_find_all(main, "div/h1")
+    (xml2::xml_text(h1[1]) == "Custom LOT")
+    (xml2::xml_text(h1[2]) == "Custom LOF")
+
+    # cleaning
+    unlink(tmp_dir, recursive = TRUE)
+  }
+})


### PR DESCRIPTION
This close #280 

For context,  Release note is telling us the issue (https://pandoc.org/releases.html#pandoc-2.17-2022-01-12)

> Functions of name Doc are no longer accepted as alternatives for Pandoc filter functions. This functionality was undocumented.

It seems just renaming is ok. 

I'll wait for the test to run, and try to add some test to check LOT / LOF are correctly present in our resulting documents. 

I'll merge once done.