### PR TITLE
Support in LOF images inserted with markdown syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.17.1
+Version: 0.17.2
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN pagedown VERSION 0.18
 
+- Figure inserted using markdown syntax and having a caption with `(#fig:lab)` are now correctly listed in the LOF (thanks, @adamvi, #283).
+
 - Fix an issue in `jss_paged()` with Pandoc 2.17 and above.
 
 - Fix an issue in `html_paged()` with LOT and LOF not showing anymore with Pandoc 2.17 and above (thanks, @adamvi, #280). 

--- a/inst/rmarkdown/templates/html-paged/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/html-paged/skeleton/skeleton.Rmd
@@ -7,6 +7,8 @@ output:
     toc: true
     # change to true for a self-contained document, but it'll be a litte slower for Pandoc to render
     self_contained: false
+lot: true # insert a list of tables
+lof: true # insert a list of figures
 # uncomment this line to produce HTML and PDF in RStudio:
 #knit: pagedown::chrome_print
 ---
@@ -17,7 +19,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 # Introduction
 
-This is an example of a multi-page HTML document. See https://pagedown.rbind.io for the full documentation. The rest of this document is random text.
+This is an example of a multi-page HTML document with some options shown in YAML header. See https://pagedown.rbind.io for the full documentation. The rest of this document is random text.
 
 # Random text
 
@@ -28,19 +30,39 @@ random_markdown = function(len = 100) {
     trimws(paste(sample(c(letters, rep(' ', 10)), len, TRUE), collapse = ''))
   }
   id = function() paste(sample(letters, 8, TRUE), collapse = '')
-  figure = function() {
-    sprintf('![(#fig:%s)The R logo.](%s){width=%d%%}', id(), uri, sample(20:60, 1))
+  figure = function(i = id()) {
+    sprintf('![(#fig:%s)The R logo.](%s){width=%d%%}', i, uri, sample(20:60, 1))
   }
   tab = paste(knitr::kable(head(mtcars[, 1:5])), collapse = '\n')
-  table = function() {
-    c(sprintf('Table: (#tab:%s)A table example.', id()), tab)
+  table = function(i = id()) {
+    c(sprintf('Table: (#tab:%s)A table example.', i), tab)
   }
   unlist(lapply(seq_len(len), function(i) {
     if (i %% 20 == 0) return(paste('#', text(sample(10:30, 1))))
     if (i %% 10 == 0) return(paste('##', text(sample(10:30, 1))))
+    # insure some elements
+    if (i == 3) return(text(50))
+    if (i == 4) return(figure("md-fig"))
+    if (i == 5) return(text(50))
+    if (i == 6) return(table("md-tab"))
+    # then random
     type = sample(1:3, 1, prob = c(.9, .03, .07))
     switch(type, text(sample(50:300, 1)), figure(), table())
   }))
 }
 cat(random_markdown(), sep = '\n\n')
+```
+
+# Knitr inserted Figures and tables
+
+## Simple graphics
+
+```{r simple-graphic, fig.cap = 'A very simple plot'}
+plot(1)
+```
+
+## Simple tables
+
+```{r simple-table}
+knitr::kable(head(mtcars, 3), caption = "A Simple table")
 ```

--- a/tests/test-ci/test-features.R
+++ b/tests/test-ci/test-features.R
@@ -6,13 +6,13 @@ assert('Page breaks work', {
 })
 
 assert('lot / lof are inserted correctly', {
+  # This test is tied to skeleton.Rmd for html-paged template
+  # Check when skeleton.Rmd is modified
   if (xfun::loadable("xml2")) {
     dir.create(tmp_dir <- tempfile())
     xfun::in_dir(tmp_dir, {
       # use included template
       rmarkdown::draft("test.Rmd", "html-paged", "pagedown", edit = FALSE)
-      # add lot / lof
-      xfun::gsub_file("test.Rmd", pattern = "^---$", replacement = "---\nlot: true\nlof: true")
       res = rmarkdown::render("test.Rmd", quiet = TRUE)
     })
     content <- xml2::read_html(res, encoding = "UTF-8")
@@ -28,7 +28,11 @@ assert('lot / lof are inserted correctly', {
     main <- xml2::xml_find_all(content, "//div[contains(@class, 'main')]")
     divs <- xml2::xml_find_all(main, "div[@id]")
     (xml2::xml_attr(divs[1], 'id') == "LOT")
+    (length(xml2::xml_find_all(divs[1], 'ul/li/a[contains(@href, "md-tab")]')) == 1L)
+    (length(xml2::xml_find_all(divs[1], 'ul/li/a[contains(@href, "simple-tab")]')) == 1L)
     (xml2::xml_attr(divs[2], 'id') == "LOF")
+    (length(xml2::xml_find_all(divs[2], 'ul/li/a[contains(@href, "md-fig")]')) == 1L)
+    (length(xml2::xml_find_all(divs[2], 'ul/li/a[contains(@href, "simple-graphic")]')) == 1L)
 
     # Change titles
     xfun::in_dir(tmp_dir, {


### PR DESCRIPTION
This should close #282 

Template has been updated to add some syntax cases that we can test for existence in our test.

With this PR, using markdown syntax to insert images should not work to be listed as long as the `#fig:` prefix is used in caption as expected by **bookdown**