### PR TITLE
remove output file before running chrome printing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Set `overflow-x: clip` in `default.css` to fix an issue with paged.js rendering in recent browser (thanks, @jimjam-slam, #292, pagedjs/pagedjs#84).
 
+- `chrome_print()` now attempts to remove the output file before printing to it and throws a clear error if it cannot be removed, as this is potential sign of a locked file, e.g a pdf opened in a PDF reader on Windows (thanks, @aito123, #124, #297).
+
 # CHANGES IN pagedown VERSION 0.18
 
 - Figure inserted using markdown syntax and having a caption with `(#fig:lab)` are now correctly listed in the LOF (thanks, @adamvi, #283).

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -172,6 +172,15 @@ chrome_print = function(
     if (missing(output) && !file.exists(input))
       output = xfun::with_ext(basename(gsub('[#?].*', '', url)), format)
     output2 = normalizePath(output, mustWork = FALSE)
+    # try to remove the file and throw a clear error if it still exists as it may be locked
+    if (!suppressWarnings(file.remove(output2)) && xfun::file_exists(output2)) {
+      stop(
+        sprintf("The file %s cannot be removed%s.",
+                sQuote(output),
+                if (format == "pdf") " (may be locked by a PDF reader)" else ""
+        )
+      )
+    }
     if (!dir.exists(d <- dirname(output2)) && !dir.create(d, recursive = TRUE)) stop(
       'Cannot create the directory for the output file: ', d
     )

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -175,10 +175,8 @@ chrome_print = function(
     # try to remove the file and throw a clear error if it still exists as it may be locked
     if (!suppressWarnings(file.remove(output2)) && xfun::file_exists(output2)) {
       stop(
-        sprintf("The file %s cannot be removed%s.",
-                sQuote(output),
-                if (format == "pdf") " (may be locked by a PDF reader)" else ""
-        )
+        "The file '", output, "' cannot be overwritten",
+        if (format == "pdf") " (may be locked by a PDF reader?)", "."
       )
     }
     if (!dir.exists(d <- dirname(output2)) && !dir.create(d, recursive = TRUE)) stop(


### PR DESCRIPTION
and throw clear error if possibly locked

closes #297 