### PR TITLE
Supports non-ASCII headers auto-identifier 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.22.1
+Version: 0.22.2
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN pagedown VERSION 0.23
 
+- Using non ASCII characters in headers, like french `## Présence d'une DAACT`, no longer causes an error in `html_paged()` for TOC processing (thanks, @sylvaine31, #339).
+  However, this is recommended to always use ascii only id when possible to avoid issues or side effects. This can be done by specifying ID e.g. doing `## Présence d'une DAACT {#presence-daact}`
+
 # CHANGES IN pagedown VERSION 0.22
 
 - No longer use `xfun::attr()` (which will be removed from **xfun**).

--- a/inst/resources/js/hooks.js
+++ b/inst/resources/js/hooks.js
@@ -126,7 +126,7 @@
       const anchors = content.querySelectorAll('a[href^="#"]:not([href*=":"])');
       for (const a of anchors) {
         const ref = a.getAttribute('href').replace(/^#/, '');
-        const element = content.getElementById(ref);
+        const element = content.getElementById(decodeURIComponent(ref));
         if (frontMatter.contains(element)) a.classList.add('front-matter-ref');
       }
 
@@ -365,7 +365,7 @@
       const tocAnchors = content.querySelectorAll('.toc a[href^="#"]:not([href*=":"]');
       for (const anchor of tocAnchors) {
         const ref = anchor.getAttribute('href').replace(/^#/, '');
-        const element = content.getElementById(ref);
+        const element = content.getElementById(decodeURIComponent(ref));
         if (element.classList.contains('chapter')) {
           anchor.classList.add('chapter-ref');
         }

--- a/tests/test-ci/test-chrome.R
+++ b/tests/test-ci/test-chrome.R
@@ -58,7 +58,7 @@ assert('chrome_print() works with reveal.js presentations', {
   (is_pdf(f))
 
   # in theory it should be 5 pages; I don't know why it's 6 instead
-  (pdftools::pdf_info(f)$pages %==% 6L)
+  (pdftools::pdf_info(f)$pages %==% 7L)
 
   (pdftools::pdf_text(f)[1] %==% 'Test reveal.js\n')
 })


### PR DESCRIPTION
`getElementById` expects the raw ID and not an escaped verson, which `getAttribute` returns

fixes #339