### PR TITLE
fix: namespace-qualify chrome_print() in test helper

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@ inst/examples$
 ^codecov\.yml$
 ^\.github$
 ^LICENSE\.md$
+^\.positai$
+^\.claude$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,7 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }}) [Pandoc ${{matrix.config.pandoc}}]
 
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+.positai
+AGENTS.md

--- a/tests/test-ci.R
+++ b/tests/test-ci.R
@@ -1,7 +1,7 @@
 # run tests on CI (these tests depend on Chrome)
 
 print_pdf = function(input, output = tempfile(), ...) {
-  chrome_print(input, output, ...)
+  pagedown::chrome_print(input, output, ...)
 }
 
 if (!is.na(Sys.getenv('CI', NA))) {


### PR DESCRIPTION
testit 0.16 removed the `library(package)` call from `test_pkg()`, so the pagedown package is no longer attached to the search path during tests. Since `print_pdf()` is defined in the runner script (`tests/test-ci.R`, global env), its enclosing environment is the global env — and `chrome_print` is no longer findable through the search path.

Fix: use `pagedown::chrome_print()` instead of bare `chrome_print()`.

Other pagedown functions called directly in the test files (`find_chrome`, `find_gs`, `gs_available`) are unaffected because they run inside the test environment whose parent is `getNamespace("pagedown")`.