### PR TITLE
Only treat a main-document HTTP error as fatal in chrome_print()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pagedown
 Type: Package
 Title: Paginate the HTML Output of R Markdown with CSS for Print
-Version: 0.24.1
+Version: 0.24.2
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Romain", "Lesur", role = c("aut", "cph"), comment = c(ORCID = "0000-0002-0721-5595")),
@@ -23,7 +23,7 @@ Description: Use the paged media properties in CSS and the JavaScript
 Depends: R (>= 3.5.0)
 Imports: rmarkdown (>= 2.13), bookdown (>= 0.8), htmltools, jsonlite, later (>= 1.0.0),
   processx, servr (>= 0.31), httpuv, xfun, websocket
-Suggests: 
+Suggests:
     promises,
     testit,
     xaringan,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN pagedown VERSION 0.25
 
+- Fixed an issue where figures inserted using Markdown syntax with a bookdown identifier `(#fig:)` were not included in the List of Figures when using Pandoc 3 (thanks, @remlapmot, #347).
+
+- `chrome_print()` no longer treats HTTP errors for sub-resources (e.g., a missing `favicon.ico`, images, or fonts) as fatal. Only errors for the main document now raise an error (thanks, @remlapmot, #347).
+
 # CHANGES IN pagedown VERSION 0.24
 
 - Fixed the bug that horizontal lines are not added below unnumbered h1 headers in the `poster_jacobs` format (thanks, @djsimmonds, #345).

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -633,7 +633,10 @@ print_page = function(
     if (!is.null(method)) {
       if (method == "Network.responseReceived") {
         status = as.numeric(msg$params$response$status)
-        if (status >= 400) {
+        # only treat a failure of the main document as fatal; sub-resources such
+        # as favicon.ico, images or fonts may legitimately 404 without affecting
+        # the rendered output (the browser still loads the page)
+        if (status >= 400 && identical(msg$params$type, "Document")) {
           token$error = sprintf(
             'Failed to open %s (HTTP status code: %s)', msg$params$response$url, status
           )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You may install this package from Github:
 pak::pak('rstudio/pagedown')
 ```
 
-This package requires a recent version of Pandoc (>= 2.2.3). If you use RStudio, you are recommended to install the [latest version](https://posit.co/download/rstudio-desktop/) (>= 1.2.1335), which has bundled Pandoc 2.x, otherwise you need to install Pandoc separately.
+This package requires a recent version of Pandoc (>= 2.2.3). If you use RStudio, you are recommended to install the [latest version](https://docs.posit.co/ide/user/#rstudio-ide-oss-downloads) (>= 1.2.1335), which has bundled Pandoc 2.x, otherwise you need to install Pandoc separately.
 
 Below are some existing R Markdown output formats and examples.
 

--- a/inst/resources/lua/loft.lua
+++ b/inst/resources/lua/loft.lua
@@ -118,6 +118,24 @@ local function addFigRef2(img)
   end
 end
 
+-- Pandoc >= 3.0 wraps a lone image in a native Figure element instead of
+-- setting the image title to "fig:" (the implicit_figures behaviour that
+-- addFigRef2 relies on). Inspect the Figure caption for a bookdown id so that
+-- Markdown-syntax figures still appear in the list of figures.
+local function addFigRef3(fig)
+
+  local captionText
+
+  -- do not build the lof if not required
+  if not options.lof then return nil end
+
+  captionText = pandoc.utils.stringify(fig.caption.long)
+  if string.find(captionText, "%(#fig:.*%)") then
+    refFromCaption(captionText, figuresList)
+  end
+  return nil -- Do not modify Figure
+end
+
 -- This function inspects the tables captions.
 -- When a bookdown id is found, it builds and saves the items used by
 --  the list of tables.
@@ -175,7 +193,16 @@ local function appendLoft(doc)
 end
 
 -- Organize filters: Meta filter needs to run before others
+local lofFilter = {Div = addFigRef, Image = addFigRef2, Table = addTabRef, Pandoc = appendLoft}
+
+-- Pandoc 3.0 introduced the native Figure element for Markdown-syntax figures,
+-- which the Image filter no longer catches. Only register the Figure handler
+-- when it is available to keep the filter working with older Pandoc versions.
+if pandocAvailable {3,0,0} then
+  lofFilter.Figure = addFigRef3
+end
+
 return {
   {Meta = getMeta},
-  {Div = addFigRef, Image = addFigRef2, Table = addTabRef, Pandoc = appendLoft}
+  lofFilter
 }

--- a/tests/test-ci/test-chrome.R
+++ b/tests/test-ci/test-chrome.R
@@ -27,6 +27,17 @@ run_promise = function(x) {
   state$value
 }
 
+# Extract the PDF outline as a nested list of title/children, comparable across
+# pdftools versions. pdftools >= 3.8.0 added an `is_open` field to pdf_toc(),
+# which also shifted the entries from `[[2L]]` to the `children` element; we
+# therefore select `children` by name and keep only `title`/`children`.
+pdf_outline = function(file) {
+  prune = function(x) lapply(x, function(node) list(
+    title = node$title, children = prune(node$children)
+  ))
+  prune(pdftools::pdf_toc(file)$children)
+}
+
 assert('find_chrome() finds Chrome executable', {
   (nzchar(find_chrome()))
 })
@@ -73,7 +84,7 @@ assert('chrome_print() generates expected outline', {
 
   (is_pdf(f))
 
-  toc = pdftools::pdf_toc(f)[[2L]]
+  toc = pdf_outline(f)
   res = list(
     list(title = "1 Title 1", children = list()),
     list(
@@ -97,14 +108,14 @@ assert('chrome_print() generates expected outline', {
   # works for async
   f = run_promise(print_pdf('test-outline.Rmd', async = TRUE))
   (is_pdf(f))
-  toc = pdftools::pdf_toc(f)[[2L]]
+  toc = pdf_outline(f)
   (toc %==% res)
 
   # works for output name with non-ASCII & white space
   output = tempfile(pattern = "\u4e2d \u6587")
   f = print_pdf('test-outline.Rmd', output = output)
   (is_pdf(f))
-  toc = pdftools::pdf_toc(f)[[2L]]
+  toc = pdf_outline(f)
   (toc %==% res)
 
   # works for input name with non-ASCII & white space
@@ -112,6 +123,6 @@ assert('chrome_print() generates expected outline', {
   file.copy('test-outline.Rmd', input)
   f = print_pdf(input)
   (is_pdf(f))
-  toc = pdftools::pdf_toc(f)[[2L]]
+  toc = pdf_outline(f)
   (toc %==% res)
 })


### PR DESCRIPTION
In `print_page()` the `Network.responseReceived` handler currently rejects on any response with an HTTP status >= 400, so a single failing sub-resource (favicon.ico, an image, a font, or a missing stylesheet such as custom.css) aborted the entire PDF even though the browser renders the page regardless.

Restricting the fatal check to `msg$params$type == "Document"` means only a failure to load the main document stops generation, matching browser behaviour. 

Fixes the favicon.ico and custom.css 404 failures reported in #338 

Fixes #338 (and the earlier #329/#331/#334).
